### PR TITLE
Add support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM seegno/node:7-slim
+
+USER root
+
+RUN apk --no-cache --virtual add sqlite
+
+USER node
+
+RUN npm install
+
+COPY . ./
+
+RUN npm rebuild
+
+CMD ["bin/wwww"]

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,6 +5,8 @@ var nconf = require('nconf');
 
 nconf
   .argv()
+  .env('__')
+  .file('db', { file: __dirname+'/../config/db.json' })
   .file('localisation', { file: __dirname+'/../config/localisation.json' })
   .file({ file: __dirname+'/../config/app.json' });
 

--- a/lib/model/db/index.js
+++ b/lib/model/db/index.js
@@ -4,8 +4,9 @@ var fs        = require("fs");
 var path      = require("path");
 var Sequelize = require("sequelize");
 var env       = process.env.NODE_ENV || "development";
-var config    = require(__dirname + '/../../../config/db.json')[env];
-var sequelize = new Sequelize(config.database, config.username, config.password, config);
+var config    = require("../../config");
+var dbConfig  = config.get(env);
+var sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig);
 var db        = {};
 
 fs

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ldapauth-fork": "^2.5.2",
     "moment": "^2.11.2",
     "morgan": "^1.3.2",
+    "mysql": "^2.12.0",
     "nconf": "^0.8.4",
     "node-uuid": "^1.4.7",
     "nodemailer": "^1.11.0",


### PR DESCRIPTION
This PR adds support for using Docker by adding the `Dockerfile` and  `.dockerignore` necessary to build images of the application.

It was also necessary to add support for using environment variables to configure the application and to add the missing dependency `mysql` to package.json.