### PR TITLE
Updates installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install TimeOff.Management application within your infrastructure:
 (make sure you have Node.js and SQLite installed)
 
 ```bash
-git clone git@github.com:timeoff-management/application.git
+git clone https://github.com/timeoff-management/application.git timeoff-management
 cd timeoff-management
 npm install
 npm start


### PR DESCRIPTION
Clone with HTTPS urls as recommended by github:
https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended
Solves error "The authenticity of host 'github.com (192.30.253.113)' can't be established."

Create timeoff-management directory instead of directory "application".