### PR TITLE
Use UTC to avoid timezone bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,8 +62,8 @@ app.use(function(req,res,next){
     res.locals.url_to_the_site_root = '/';
     res.locals.requested_path = req.originalUrl;
     // For book leave request modal
-    res.locals.booking_start = moment();
-    res.locals.booking_end = moment();
+    res.locals.booking_start = moment().utc();
+    res.locals.booking_end = moment().utc();
     next();
 });
 

--- a/lib/model/calendar_month.js
+++ b/lib/model/calendar_month.js
@@ -6,7 +6,7 @@ var moment = require('moment'),
 
 function CalendarMonth(day, args){
     var me = this;
-    this.date           = moment(day).startOf('month');
+    this.date           = moment.utc(day).startOf('month');
     this._leaves        = {};
     this._bank_holidays = {};
 
@@ -21,7 +21,7 @@ function CalendarMonth(day, args){
     if (args && args.bank_holidays){
         var map = {};
         args.bank_holidays.forEach(function(day){
-            day = moment(day);
+            day = moment.utc(day);
             map[day.format(me.default_date_format())] = day;
         });
         this._bank_holidays = map;
@@ -30,7 +30,7 @@ function CalendarMonth(day, args){
     if (args && args.leave_days){
         var map = {};
         args.leave_days.forEach(function(day){
-            var attribute = moment(day.date).format(me.default_date_format());
+            var attribute = moment.utc(day.date).format(me.default_date_format());
             if ( ! map[attribute] ) {
                 map[attribute] = day;
             } else if ( map[attribute] ) {
@@ -146,7 +146,7 @@ CalendarMonth.prototype.is_weekend = function(day){
 CalendarMonth.prototype.is_current_day = function(day){
   return this.get_base_date().date(day).format( this.default_date_format() )
     ===
-    moment().format( this.default_date_format() );
+    moment.utc().format( this.default_date_format() );
 };
 
 CalendarMonth.prototype.as_for_template = function(){

--- a/lib/model/db/bank_holiday.js
+++ b/lib/model/db/bank_holiday.js
@@ -63,7 +63,7 @@ module.exports = function(sequelize, DataTypes) {
 
         instanceMethods : {
           get_pretty_date : function(){
-            return moment(this.date).format('YYYY-MM-DD');
+            return moment.utc(this.date).format('YYYY-MM-DD');
           },
         }
     });

--- a/lib/model/db/leave.js
+++ b/lib/model/db/leave.js
@@ -132,8 +132,8 @@ module.exports = function(sequelize, DataTypes) {
 
               .then(function(superviser){
 
-                  var start_date = moment(valide_attributes.from_date),
-                  end_date       = moment(valide_attributes.to_date);
+                  var start_date = moment.utc(valide_attributes.from_date),
+                  end_date       = moment.utc(valide_attributes.to_date);
 
                   // Check that start date is not bigger then end one
                   if ( start_date.toDate() > end_date.toDate() ) {
@@ -174,8 +174,8 @@ module.exports = function(sequelize, DataTypes) {
 get_days : function() {
 
   var self   = this,
-  start_date = moment(this.date_start),
-  end_date   = moment(this.date_end),
+  start_date = moment.utc(this.date_start),
+  end_date   = moment.utc(this.date_end),
   days       = [ start_date ];
 
   if (self.hasOwnProperty('_days')) {
@@ -302,7 +302,7 @@ get_deducted_days : function(args) {
   }
 
   if (args && args.hasOwnProperty('year')) {
-    year = moment(args.year, 'YYYY');
+    year = moment.utc(args.year, 'YYYY');
   }
 
   // If current Leave stands for type that does not use
@@ -330,10 +330,10 @@ get_deducted_days : function(args) {
 
       // If it happenned that current leave day is from the year current
       // call was made of, ignore that day
-      if (year && year.year() !== moment(leave_day.date).year()) return;
+      if (year && year.year() !== moment.utc(leave_day.date).year()) return;
 
       // Ignore non-working days (weekends)
-      if ( ! schedule.is_it_working_day({ day : moment(leave_day.date) }) ){
+      if ( ! schedule.is_it_working_day({ day : moment.utc(leave_day.date) }) ){
         return;
       }
 

--- a/lib/model/db/schedule.js
+++ b/lib/model/db/schedule.js
@@ -120,7 +120,7 @@ module.exports = function(sequelize, DataTypes){
           throw new Error('"is_it_working_day" requires to have "day" parameter');
         }
 
-        return this[ moment(day).format('dddd').toLowerCase() ] === works_whole_day();
+        return this[ moment.utc(day).format('dddd').toLowerCase() ] === works_whole_day();
       },
 
       works_monday : function(){

--- a/lib/model/db/user.js
+++ b/lib/model/db/user.js
@@ -185,7 +185,7 @@ function get_instance_methods(sequelize) {
 
     calculate_number_of_days_available_in_allowance : function(year){
       if (! year ){
-        year = moment().format('YYYY');
+        year = moment.utc().format('YYYY');
       }
       return this.calculate_total_number_of_days_n_allowance(year)
         - this.calculate_number_of_days_taken_from_allowance({year : year});
@@ -193,7 +193,7 @@ function get_instance_methods(sequelize) {
 
 
     reload_with_leave_details : function(args){
-      var year = args.year || moment(),
+      var year = args.year || moment.utc(),
         self = this;
 
       return Promise.join(
@@ -472,7 +472,7 @@ function get_class_methods(sequelize) {
       return {
         $or : [
           { end_date : {$eq : null}},
-          { end_date : {$gte : moment().startOf('day').format('YYYY-MM-DD') }},
+          { end_date : {$gte : moment.utc().startOf('day').format('YYYY-MM-DD') }},
         ],
       };
     },

--- a/lib/model/leave_day.js
+++ b/lib/model/leave_day.js
@@ -54,7 +54,7 @@ LeaveDay.prototype.pretend_to_be_full_day = function() {
 };
 
 LeaveDay.prototype.get_pretty_date = function(){
-  return moment(this.date).format('YYYY-MM-DD');
+  return moment.utc(this.date).format('YYYY-MM-DD');
 };
 
 module.exports = LeaveDay;

--- a/lib/model/leave_request_parameters.js
+++ b/lib/model/leave_request_parameters.js
@@ -23,7 +23,7 @@ function LeaveRequest(args) {
     );
 
     // From date should not be bigger then to
-    if (moment(args.from_date).toDate() > moment(args.to_date).toDate()){
+    if (moment.utc(args.from_date).toDate() > moment.utc(args.to_date).toDate()){
         throw new Error( 'From date should be before To date at LeaveRequest constructor' );
     }
 
@@ -52,9 +52,9 @@ LeaveRequest.prototype.as_data_object = function(){
 };
 
 LeaveRequest.prototype.is_within_one_day = function(){
-    return moment(this.from_date).format('YYYY-MM-DD')
+    return moment.utc(this.from_date).format('YYYY-MM-DD')
           ===
-        moment(this.to_date).format('YYYY-MM-DD');
+        moment.utc(this.to_date).format('YYYY-MM-DD');
 };
 
 LeaveRequest.prototype._does_fit_with_point = function(leave_day, point_name){
@@ -62,9 +62,9 @@ LeaveRequest.prototype._does_fit_with_point = function(leave_day, point_name){
 
     if (
         (
-          moment(leave_day.date).format('YYYY-MM-DD')
+          moment.utc(leave_day.date).format('YYYY-MM-DD')
             ===
-          moment(this[point_name]).format('YYYY-MM-DD')
+          moment.utc(this[point_name]).format('YYYY-MM-DD')
         )
           &&
         (! leave_day.is_all_day_leave())

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -21,23 +21,23 @@ module.exports = function(sequelize){
 
     if (show_full_year) {
       return _.map([1,2,3,4,5,6,7,8,9,10,11,12], function(i){
-        return moment(year.format('YYYY')+'-'+i+'-01');
+        return moment.utc(year.format('YYYY')+'-'+i+'-01');
       });
     }
 
     return _.map([0,1,2,3], function(delta){
-      return moment().add(delta, 'months').startOf('month');
+      return moment.utc().add(delta, 'months').startOf('month');
     })
   };
 
 
   this.promise_calendar = function(args) {
-    var year       = args.year || moment(),
+    var year       = args.year || moment.utc(),
     show_full_year = args.show_full_year || false,
     model          = sequelize.models,
     this_user      = this,
     // Find or if we need to show multi year calendar
-    is_multi_year = moment().month() > 8;
+    is_multi_year = moment.utc().month() > 8;
 
     var months_to_show = this_user._get_calendar_months_to_show({
       year           : year.clone(),
@@ -69,16 +69,16 @@ module.exports = function(sequelize){
             $or : {
               date_start : {
                 $between : [
-                  moment(year).startOf('year').format('YYYY-MM-DD'),
-                  moment(
+                  moment.utc(year).startOf('year').format('YYYY-MM-DD'),
+                  moment.utc(
                     year.clone().add((is_multi_year ? 1 : 0), 'years')
                   ).endOf('year').format('YYYY-MM-DD'),
                 ]
               },
               date_end : {
                 $between : [
-                  moment( year ).startOf('year').format('YYYY-MM-DD'),
-                  moment(
+                  moment.utc( year ).startOf('year').format('YYYY-MM-DD'),
+                  moment.utc(
                     year.clone().add((is_multi_year ? 1 : 0), 'years')
                   ).endOf('year').format('YYYY-MM-DD'),
                 ]
@@ -130,7 +130,7 @@ module.exports = function(sequelize){
     var days_filter = {
       $between : [
         new_leave_attributes.from_date,
-        moment(new_leave_attributes.to_date)
+        moment.utc(new_leave_attributes.to_date)
           .add(1,'days').format('YYYY-MM-DD'),
       ],
     };
@@ -180,7 +180,7 @@ module.exports = function(sequelize){
 
     var self         = this,
         where_clause = {},
-        year         = args.year || moment();
+        year         = args.year || moment.utc();
 
     if (args && args.filter_status) {
       where_clause = { status : args.filter_status };
@@ -191,14 +191,14 @@ module.exports = function(sequelize){
       where_clause['$or'] = {
         date_start : {
           $between : [
-            moment(year).startOf('year').format('YYYY-MM-DD'),
-            moment(year).endOf('year').format('YYYY-MM-DD'),
+            moment.utc(year).startOf('year').format('YYYY-MM-DD'),
+            moment.utc(year).endOf('year').format('YYYY-MM-DD'),
           ]
         },
         date_end : {
           $between : [
-            moment(year).startOf('year').format('YYYY-MM-DD'),
-            moment(year).endOf('year').format('YYYY-MM-DD'),
+            moment.utc(year).startOf('year').format('YYYY-MM-DD'),
+            moment.utc(year).endOf('year').format('YYYY-MM-DD'),
           ]
         }
       };
@@ -250,7 +250,7 @@ module.exports = function(sequelize){
 
 
   this.promise_my_active_leaves = function(args) {
-    var year = args.year || moment();
+    var year = args.year || moment.utc();
 
     return this.promise_my_leaves({
       year          : year,
@@ -424,21 +424,21 @@ module.exports = function(sequelize){
 
   this.get_automatic_adjustment = function(args) {
 
-    var now = (args && args.now) ? moment(args.now) : moment();
+    var now = (args && args.now) ? moment.utc(args.now) : moment.utc();
 
     if (
-      now.year() !== moment(this.start_date).year()
-      && ( ! this.end_date || moment(this.end_date).year() > now.year() )
+      now.year() !== moment.utc(this.start_date).year()
+      && ( ! this.end_date || moment.utc(this.end_date).year() > now.year() )
     ){
         return 0;
     }
 
-    var start_date = moment(this.start_date).year() === now.year()
-      ? moment(this.start_date)
+    var start_date = moment.utc(this.start_date).year() === now.year()
+      ? moment.utc(this.start_date)
       : now.startOf('year'),
-    end_date = this.end_date && moment(this.end_date).year() <= now.year()
-      ? moment(this.end_date)
-      : moment().endOf('year');
+    end_date = this.end_date && moment.utc(this.end_date).year() <= now.year()
+      ? moment.utc(this.end_date)
+      : moment.utc().endOf('year');
 
     return -1*(this.department.allowance - Math.round(
       this.department.allowance * end_date.diff(start_date, 'days') / 365
@@ -451,7 +451,7 @@ module.exports = function(sequelize){
     // If optional paramater year was provided we need to calculate allowance
     // for that year, and if it is something other then current year,
     // adjustment should be made, return nominal setting from department
-    if (year && year != moment().year()) {
+    if (year && year != moment.utc().year()) {
       return this.department.allowance
     }
 
@@ -464,7 +464,7 @@ module.exports = function(sequelize){
 
 
   this.promise_my_leaves_for_calendar = function(args){
-    var year = args.year || moment();
+    var year = args.year || moment.utc();
 
     return this.getMy_leaves({
       where : {
@@ -477,14 +477,14 @@ module.exports = function(sequelize){
         $or : {
           date_start : {
             $between : [
-              moment(year).startOf('year').format('YYYY-MM-DD'),
-              moment(year).endOf('year').format('YYYY-MM-DD'),
+              moment.utc(year).startOf('year').format('YYYY-MM-DD'),
+              moment.utc(year).endOf('year').format('YYYY-MM-DD'),
             ]
           },
           date_end : {
             $between : [
-              moment(year).startOf('year').format('YYYY-MM-DD'),
-              moment(year).endOf('year').format('YYYY-MM-DD'),
+              moment.utc(year).startOf('year').format('YYYY-MM-DD'),
+              moment.utc(year).endOf('year').format('YYYY-MM-DD'),
             ]
           }
         }
@@ -503,7 +503,7 @@ module.exports = function(sequelize){
     leave_type = args.leave_type,
     leave      = args.leave,
     // Derive year from Leave object
-    year       = args.year || moment(leave.date_start);
+    year       = args.year || moment.utc(leave.date_start);
 
     // Make sure object contain all necessary data for that check
     return self.reload_with_leave_details({

--- a/lib/model/mixin/user/company_aware.js
+++ b/lib/model/mixin/user/company_aware.js
@@ -23,7 +23,7 @@ module.exports = function(sequelize){
    */
   this.get_company_for_user_details = function(args){
     var user_id    = args.user_id,
-      year         = args.year || moment(),
+      year         = args.year || moment.utc(),
       current_user = this;
 
     return this.getCompany({
@@ -44,14 +44,14 @@ module.exports = function(sequelize){
                 $or : {
                   date_start : {
                     $between : [
-                      moment().startOf('year').format('YYYY-MM-DD'),
-                      moment().endOf('year').format('YYYY-MM-DD'),
+                      moment.utc().startOf('year').format('YYYY-MM-DD'),
+                      moment.utc().endOf('year').format('YYYY-MM-DD'),
                     ]
                   },
                   date_end : {
                     $between : [
-                      moment().startOf('year').format('YYYY-MM-DD'),
-                      moment().endOf('year').format('YYYY-MM-DD'),
+                      moment.utc().startOf('year').format('YYYY-MM-DD'),
+                      moment.utc().endOf('year').format('YYYY-MM-DD'),
                     ]
                   }
                 }

--- a/lib/model/team_view.js
+++ b/lib/model/team_view.js
@@ -8,7 +8,7 @@ _          = require('underscore');
 function TeamView(args) {
   var me = this;
 
-  this.base_date = args.base_date || moment();
+  this.base_date = args.base_date || moment.utc();
   this.user = args.user;
 }
 

--- a/lib/route/audit.js
+++ b/lib/route/audit.js
@@ -80,11 +80,11 @@ router.get(/email/, function(req, res){
       };
 
       if (start_date) {
-        filter.start_date = moment(start_date).format(req.user.company.get_default_date_format());
+        filter.start_date = moment.utc(start_date).format(req.user.company.get_default_date_format());
       }
 
       if (end_date) {
-        filter.end_date = moment(end_date).format(req.user.company.get_default_date_format());
+        filter.end_date = moment.utc(end_date).format(req.user.company.get_default_date_format());
       }
 
       res.render('audit/emails', {

--- a/lib/route/calendar.js
+++ b/lib/route/calendar.js
@@ -95,8 +95,8 @@ router.get('/', function(req, res) {
   );
 
   var current_year = validator.isNumeric(req.param('year'))
-    ? moment(req.param('year'), 'YYYY')
-    : moment();
+    ? moment.utc(req.param('year'), 'YYYY')
+    : moment.utc();
 
   var show_full_year = validator.toBoolean(req.param('show_full_year'));
 
@@ -117,15 +117,15 @@ router.get('/', function(req, res) {
         title          : 'Calendar',
         current_user   : user,
         superviser     : superviser,
-        previous_year  : moment(current_year).add(-1,'year').format('YYYY'),
+        previous_year  : moment.utc(current_year).add(-1,'year').format('YYYY'),
         current_year   : current_year.format('YYYY'),
-        next_year      : moment(current_year).add(1,'year').format('YYYY'),
+        next_year      : moment.utc(current_year).add(1,'year').format('YYYY'),
         show_full_year : show_full_year,
         leave_type_statistics : _.filter(full_leave_type_statistics, function(st){
           return st.days_taken > 0;
         }),
         full_leave_type_statistics : full_leave_type_statistics,
-        this_year : moment().format('YYYY'),
+        this_year : moment.utc().format('YYYY'),
       });
     }
   );
@@ -140,8 +140,8 @@ router.get('/teamview/', function(req, res){
   );
 
   var base_date = validator.isDate(req.param('date'))
-    ? moment(req.param('date'))
-    : moment();
+    ? moment.utc(req.param('date'))
+    : moment.utc();
 
   var team_view = new TeamView({
     base_date : base_date,
@@ -161,8 +161,8 @@ router.get('/teamview/', function(req, res){
 
       return res.render('team_view', {
         base_date           : base_date,
-        prev_date           : moment(base_date).add(-1,'month'),
-        next_date           : moment(base_date).add(1,'month'),
+        prev_date           : moment.utc(base_date).add(-1,'month'),
+        next_date           : moment.utc(base_date).add(1,'month'),
         users_and_leaves    : team_view_details.users_and_leaves,
         related_departments : team_view_details.related_departments,
         current_department  : team_view_details.current_department,

--- a/lib/route/feed.js
+++ b/lib/route/feed.js
@@ -44,7 +44,7 @@ router.get('/:token/ical.ics', function(req, res){
 
       if (feed.is_calendar()){
         return user.promise_calendar({
-          year           : moment(),
+          year           : moment.utc(),
           show_full_year : true,
         })
           .then(function(calendar){
@@ -93,8 +93,8 @@ router.get('/:token/ical.ics', function(req, res){
           return;
         }
 
-        var start = moment(day.moment),
-            end = moment(day.moment);
+        var start = moment.utc(day.moment),
+            end = moment.utc(day.moment);
 
         if (day.is_leave_morning && day.is_leave_afternoon) {
           start.hour(9).minute(0);

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -691,7 +691,7 @@ router.post('/company/export/', function(req, res){
     .then(function(company){
 
       res.attachment(
-        company.name_for_machine()+'_'+moment().format('YYYYMMDD-hhmmss')+'.json'
+        company.name_for_machine()+'_'+moment.utc().format('YYYYMMDD-hhmmss')+'.json'
       );
 
       res.send(JSON.stringify(company));

--- a/lib/route/users.js
+++ b/lib/route/users.js
@@ -247,7 +247,7 @@ var ensure_user_was_not_useed_elsewhere_while_being_inactive = function(args){
         // new "end_date" is provided
         // new "end_date" is in future
         new_user_attributes.end_date &&
-        moment( new_user_attributes.end_date ).startOf('day').toDate() >= moment().startOf('day').toDate()
+        moment.utc( new_user_attributes.end_date ).startOf('day').toDate() >= moment.utc().startOf('day').toDate()
       )
     )
   ) {
@@ -526,14 +526,14 @@ router.get('/', function(req, res) {
                 $or : {
                   date_start : {
                     $between : [
-                      moment().startOf('year').format('YYYY-MM-DD'),
-                      moment().endOf('year').format('YYYY-MM-DD'),
+                      moment.utc().startOf('year').format('YYYY-MM-DD'),
+                      moment.utc().endOf('year').format('YYYY-MM-DD'),
                     ]
                   },
                   date_end : {
                     $between : [
-                      moment().startOf('year').format('YYYY-MM-DD'),
-                      moment().endOf('year').format('YYYY-MM-DD'),
+                      moment.utc().startOf('year').format('YYYY-MM-DD'),
+                      moment.utc().endOf('year').format('YYYY-MM-DD'),
                     ]
                   }
                 }
@@ -668,7 +668,7 @@ function get_and_validate_user_parameters(args) {
     if (
         start_date &&
         end_date &&
-        moment(start_date).toDate() > moment(end_date).toDate()
+        moment.utc(start_date).toDate() > moment.utc(end_date).toDate()
     ){
         req.session.flash_error(
             'End date for '+item_name+' is before start date'

--- a/lib/view/helpers.js
+++ b/lib/view/helpers.js
@@ -13,7 +13,7 @@ var as_date_formatted = function(date_str, format, options) {
     format = get_current_format( options );
   }
 
-  return moment(date_str).format(format);
+  return moment.utc(date_str).format(format);
 }
 
 // Note: that currently it returns only truely value of given property, that is if there property

--- a/t/integration/bank_holidays/crud_bank_holiday.js
+++ b/t/integration/bank_holidays/crud_bank_holiday.js
@@ -75,7 +75,7 @@ describe('CRUD for bank holidays', function(){
         value    : 'Early May bank holiday',
       },{
         selector : bankholiday_form_id+' input[name="date__0"]',
-        value    : moment().format('YYYY-MM-DD'),
+        value    : moment.utc().format('YYYY-MM-DD'),
       }],
     })
     .then(function(){done()});

--- a/t/integration/deactivate_and_activate_user.js
+++ b/t/integration/deactivate_and_activate_user.js
@@ -77,7 +77,7 @@ describe('Deactivate and activate user', function(){
         driver      : driver,
         form_params : [{
           selector : 'input#end_date_inp',
-          value    : moment().subtract(1, 'days').format('YYYY-MM-DD'),
+          value    : moment.utc().subtract(1, 'days').format('YYYY-MM-DD'),
         }],
         submit_button_selector : 'button#save_changes_btn',
         message : /Details for .+ were updated/,
@@ -134,7 +134,7 @@ describe('Deactivate and activate user', function(){
       driver      : driver,
       form_params : [{
         selector : 'input#end_date_inp',
-        value    : moment().add(1, 'days').format('YYYY-MM-DD'),
+        value    : moment.utc().add(1, 'days').format('YYYY-MM-DD'),
       }],
       submit_button_selector : 'button#save_changes_btn',
       message : /There is an active account with similar email somewhere within system/,
@@ -160,7 +160,7 @@ describe('Deactivate and activate user', function(){
       driver      : driver,
       form_params : [{
         selector : 'input#end_date_inp',
-        value    : moment().subtract(3, 'days').format('YYYY-MM-DD'),
+        value    : moment.utc().subtract(3, 'days').format('YYYY-MM-DD'),
       }],
       submit_button_selector : 'button#save_changes_btn',
       message : /Details for .+ were updated/,

--- a/t/integration/inactivate_user.js
+++ b/t/integration/inactivate_user.js
@@ -194,7 +194,7 @@ describe('Dealing with inactive users', function(){
       driver      : driver,
       form_params : [{
         selector : 'input#end_date_inp',
-        value    : moment().subtract(1, 'days').format('YYYY-MM-DD'),
+        value    : moment.utc().subtract(1, 'days').format('YYYY-MM-DD'),
       }],
       submit_button_selector : 'button#save_changes_btn',
       message : /Details for .+ were updated/,

--- a/t/integration/leave_request/basic_leave_request.js
+++ b/t/integration/leave_request/basic_leave_request.js
@@ -135,8 +135,8 @@ describe('Basic leave request', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2015-06-16')],
-      halfs_1st_days : [moment('2015-06-15')],
+      full_days      : [moment.utc('2015-06-16')],
+      halfs_1st_days : [moment.utc('2015-06-15')],
       type           : 'pended',
     })
     .then(function(){done()});
@@ -226,8 +226,8 @@ describe('Basic leave request', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2015-06-16')],
-      halfs_1st_days : [moment('2015-06-15')],
+      full_days      : [moment.utc('2015-06-16')],
+      halfs_1st_days : [moment.utc('2015-06-15')],
       type           : 'approved',
     })
     .then(function(){done()});

--- a/t/integration/leave_request/book_leave_request_form.js
+++ b/t/integration/leave_request/book_leave_request_form.js
@@ -56,10 +56,10 @@ describe("Check the client side logic to facilitate filling new absence form", f
       driver : driver,
       elements_to_check : [{
         selector : 'input.book-leave-from-input',
-        value : moment().format('YYYY-MM-DD'),
+        value : moment.utc().format('YYYY-MM-DD'),
       },{
         selector : 'input.book-leave-to-input',
-        value : moment().format('YYYY-MM-DD'),
+        value : moment.utc().format('YYYY-MM-DD'),
       }],
     })
     .then(function(){ done() });
@@ -68,7 +68,7 @@ describe("Check the client side logic to facilitate filling new absence form", f
   it("Update FROM to be in future and make sure TO is automatically addusted to the same date", function(done){
 
     var inp_from,
-      tomorrow_str = moment().add(1, 'days').format('YYYY-MM-DD');
+      tomorrow_str = moment.utc().add(1, 'days').format('YYYY-MM-DD');
 
     driver
       .findElement(By.css('input.book-leave-from-input'))
@@ -95,8 +95,8 @@ describe("Check the client side logic to facilitate filling new absence form", f
   it("Update FROM to be in past and make sure TO is stays unchanged", function(done){
 
     var inp_from,
-      tomorrow_str = moment().add(1, 'days').format('YYYY-MM-DD'),
-      yesterday_str = moment().subtract(1, 'days').format('YYYY-MM-DD');
+      tomorrow_str = moment.utc().add(1, 'days').format('YYYY-MM-DD'),
+      yesterday_str = moment.utc().subtract(1, 'days').format('YYYY-MM-DD');
 
     driver
       .findElement(By.css('input.book-leave-from-input'))

--- a/t/integration/leave_request/leave_request_revoke.js
+++ b/t/integration/leave_request/leave_request_revoke.js
@@ -188,8 +188,8 @@ describe('Revoke leave request', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2017-06-16')],
-      halfs_1st_days : [moment('2017-06-15')],
+      full_days      : [moment.utc('2017-06-16')],
+      halfs_1st_days : [moment.utc('2017-06-15')],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_request/leave_request_revoke_by_admin.js
+++ b/t/integration/leave_request/leave_request_revoke_by_admin.js
@@ -127,8 +127,8 @@ describe('Revoke leave request by Admin', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2017-06-16')],
-      halfs_1st_days : [moment('2017-06-15')],
+      full_days      : [moment.utc('2017-06-16')],
+      halfs_1st_days : [moment.utc('2017-06-15')],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_request/ovelapping_bookings.js
+++ b/t/integration/leave_request/ovelapping_bookings.js
@@ -122,7 +122,7 @@ describe('Overlapping bookings', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver    : driver,
-      full_days : [moment('2015-06-15'), moment('2015-06-16')],
+      full_days : [moment.utc('2015-06-15'), moment.utc('2015-06-16')],
       type      : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_request/ovelapping_bookings_halfs.js
+++ b/t/integration/leave_request/ovelapping_bookings_halfs.js
@@ -131,8 +131,8 @@ describe('Overlapping leaverequest (with halfs)', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2015-06-17')],
-      halfs_1st_days : [moment('2015-06-16')],
+      full_days      : [moment.utc('2015-06-17')],
+      halfs_1st_days : [moment.utc('2015-06-16')],
       type           : 'pended',
     })
     .then(function(){ done() });
@@ -258,7 +258,7 @@ describe('Overlapping leaverequest (with halfs)', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver    : driver,
-      full_days : [moment('2015-06-15'),moment('2015-06-16'),moment('2015-06-17')],
+      full_days : [moment.utc('2015-06-15'),moment.utc('2015-06-16'),moment.utc('2015-06-17')],
       type      : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_type_limit_in_action.js
+++ b/t/integration/leave_type_limit_in_action.js
@@ -162,7 +162,7 @@ describe('Leave type limits in actoion', function(){
         .then(function(){
           check_booking_func({
             driver    : driver,
-            full_days : [moment('2015-06-16'),moment('2015-06-16'),moment('2015-06-17')],
+            full_days : [moment.utc('2015-06-16'),moment.utc('2015-06-16'),moment.utc('2015-06-17')],
             type      : 'pended',
           })
           .then(function(){ done() });

--- a/t/integration/leave_type_limit_next_year.js
+++ b/t/integration/leave_type_limit_next_year.js
@@ -21,7 +21,7 @@ var test             = require('selenium-webdriver/testing'),
     config                 = require('../lib/config'),
     application_host       = config.get_application_host();
 
-var next_year = moment().add(1, 'y').format('YYYY');
+var next_year = moment.utc().add(1, 'y').format('YYYY');
 
 /*
  *  Scenario to go in this test:
@@ -137,7 +137,7 @@ describe('Leave type limits for next year: ' + next_year, function(){
         .then(function(){
           check_booking_func({
             driver    : driver,
-            full_days : [moment(next_year + '-05-10')],
+            full_days : [moment.utc(next_year + '-05-10')],
             type      : 'pended',
           })
           .then(function(){ done() });

--- a/t/integration/remove_used_leave_type.js
+++ b/t/integration/remove_used_leave_type.js
@@ -122,8 +122,8 @@ describe('Try to remove used leave type', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment('2015-06-16')],
-      halfs_1st_days : [moment('2015-06-15')],
+      full_days      : [moment.utc('2015-06-16')],
+      halfs_1st_days : [moment.utc('2015-06-15')],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/unit/model/db/user.js
+++ b/t/unit/model/db/user.js
@@ -10,55 +10,55 @@ describe('get_automatic_adjustment method', function(){
 
   describe('Employee start day is in previouse year and no end date',function(){
     var employee = model.User.build({
-      start_date : moment('2015-07-14'),
+      start_date : moment.utc('2015-07-14'),
     });
 
     it('no automatic adjustment', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-07-20')}))
         .to.be.equal(0)
     });
   });
 
   describe('Employee start date is in prevouse year but end date is in current year', function(){
     var employee = model.User.build({
-      start_date : moment('2015-04-23'),
-      end_date : moment('2016-04-01'),
+      start_date : moment.utc('2015-04-23'),
+      end_date : moment.utc('2016-04-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('ajustment is made based on end date', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-02-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-02-20')}))
         .to.be.equal(-15);
     });
   });
 
   describe('Employee start date is in previouse year and end date is in next year', function(){
    var employee = model.User.build({
-      start_date : moment('2015-04-23'),
-      end_date : moment('2017-04-01'),
+      start_date : moment.utc('2015-04-23'),
+      end_date : moment.utc('2017-04-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('ajustment is made based on end date', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-07-20')}))
         .to.be.equal(0);
     });
   });
 
   describe('Start date is in current year, no end date', function(){
     var employee = model.User.build({
-      start_date : moment('2017-04-01'),
+      start_date : moment.utc('2017-04-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('adjustment is made based on start date', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2017-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2017-07-20')}))
         .to.be.equal(-5);
     });
 
@@ -66,59 +66,59 @@ describe('get_automatic_adjustment method', function(){
 
   describe('Start date is in current year, end date is in current year either',function(){
     var employee = model.User.build({
-      start_date : moment('2016-04-01'),
-      end_date : moment('2016-10-01'),
+      start_date : moment.utc('2016-04-01'),
+      end_date : moment.utc('2016-10-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('adjustment is made based on start and end dates', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-07-20')}))
         .to.be.equal(-10);
     });
   });
 
   describe('Start date is in current year, end date is in next year', function(){
     var employee = model.User.build({
-      start_date : moment('2017-04-01'),
-      end_date : moment('2018-10-01'),
+      start_date : moment.utc('2017-04-01'),
+      end_date : moment.utc('2018-10-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('adjustment is made based on start date', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2017-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2017-07-20')}))
         .to.be.equal(-5);
     });
   });
 
   describe('Start date is in next year, no end date', function(){
     var employee = model.User.build({
-      start_date : moment('2017-04-01'),
+      start_date : moment.utc('2017-04-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('No adjustment is needed', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-07-20')}))
         .to.be.equal(0);
     });
   });
 
   describe('Start date is in next year, end date is defined',function(){
     var employee = model.User.build({
-      start_date : moment('2017-04-01'),
-      end_date : moment('2017-10-01'),
+      start_date : moment.utc('2017-04-01'),
+      end_date : moment.utc('2017-10-01'),
     });
     employee.department = {
       allowance : 20,
     };
 
     it('No adjustment is needed', function(){
-      expect(employee.get_automatic_adjustment({now : moment('2016-07-20')}))
+      expect(employee.get_automatic_adjustment({now : moment.utc('2016-07-20')}))
         .to.be.equal(0);
     });
   });


### PR DESCRIPTION
Timezones are not required for the application, though not dealing with them causes a bug as per https://github.com/timeoff-management/application/issues/107

Setting time use to UTC ensures that time comparisons work regardless of timezone. 

env TZ='America/New_York' npm test - all tests pass