### PR TITLE
Remove duplicated book_leave_modal element from team view page

### DIFF
--- a/views/team_view.hbs
+++ b/views/team_view.hbs
@@ -70,6 +70,4 @@
 
 <div class="row clearfix">&nbsp;</div>
 
-{{> book_leave_modal container_id='book_leave_modal' leave_modal_form_action='/calendar/bookleave/' redirect_back_to='/calendar/teamview/'}}
-
 {{> footer }}


### PR DESCRIPTION
Fixes https://github.com/timeoff-management/application/issues/188

I understand that this leave modal is different than the one from footer because of `redirect_back_to='/calendar/teamview/'`

which is not present in he footer https://github.com/timeoff-management/application/blob/master/views/partials/footer.hbs#L2

But the testing did not provide any problems. After adding new absence I always stayed on the team view.  So I would say this is not necessary to have. 

All tests are green:

![image](https://user-images.githubusercontent.com/8086995/32500503-ed13cbec-c3d5-11e7-8876-30e556245fbd.png)

