### PR TITLE
Exposed color support to the gui. 

### DIFF
--- a/lib/model/calendar_month.js
+++ b/lib/model/calendar_month.js
@@ -18,6 +18,11 @@ function CalendarMonth(day, args){
       throw new Error('CalendarMonth requires schedule');
     }
 
+    if(args && args.leave_types){
+        this.colors = {}
+        args.leave_types.forEach(t => {this.colors[t.id]=t.color});
+    }
+
     if (args && args.bank_holidays){
         var map = {};
         args.bank_holidays.forEach(function(day){
@@ -162,7 +167,9 @@ CalendarMonth.prototype.as_for_template = function(){
           val       : i,
           leave_obj : this.get_leave_obj(i),
         };
-
+        if(this.colors && day.leave_obj){
+            day.color = this.colors[day.leave_obj.leaveTypeId]
+        }
         if ( this.is_weekend(i) ) {
             day.is_weekend = true;
         } else if ( this.is_bank_holiday(i) ){

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -106,6 +106,7 @@ module.exports = function(sequelize){
             return new CalendarMonth(
               month,
               {
+                leave_types: company.leave_types,
                 bank_holidays :
                   department.include_public_holidays
                   ?  _.map(

--- a/lib/model/team_view.js
+++ b/lib/model/team_view.js
@@ -129,6 +129,13 @@ TeamView.prototype.inject_statistics = function(args){
   let leave_types_map = {};
   leave_types.forEach( lt => leave_types_map[lt.id] = lt );
 
+  team_view_details.users_and_leaves.forEach(user => {
+    user.days.forEach(day =>{
+      if(day.leave_obj){
+        day.color = leave_types_map[day.leave_obj.leaveTypeId].color
+      }
+    })
+  })
 
   team_view_details
     .users_and_leaves

--- a/views/general_settings.hbs
+++ b/views/general_settings.hbs
@@ -210,8 +210,11 @@
 
         {{#each company.leave_types}}
         <div class="row">
-          <div class="col-md-6">
+          <div class="col-md-4">
             <input type="text" class="form-control" value="{{name}}" name="name__{{@index}}">
+          </div>
+          <div class="col-md-2">
+            <input type="text" class="form-control" value="{{color}}" name="color__{{@index}}">
           </div>
           <div class="col-md-3">
             <input name="use_allowance__{{@index}}" id="use_allowance__{{@index}}" type="checkbox" {{#if use_allowance}}checked="checked"{{/if}}>

--- a/views/partials/calendar_cell.hbs
+++ b/views/partials/calendar_cell.hbs
@@ -10,7 +10,16 @@
         {{/if}}
     {{/if}}
     {{# if day.is_current_day }}current_day_cell{{/if}}
-">
+"
+{{#if day.is_leave_morning }}
+    {{#if day.is_new_leave}}
+    {{else}}
+        {{#if day.color}}
+            style="background: {{day.color}}"
+        {{/if}}
+   {{/if}}
+{{/if}}
+>
 <span
   {{#unless day.is_bank_holiday}}
     {{#unless day.is_weekend}}
@@ -55,4 +64,13 @@
         {{/if}}
     {{/if}}
     {{# if day.is_current_day }}current_day_cell{{/if}}
-"></td>
+"
+{{#if day.is_leave_afternoon }}
+    {{#if day.is_new_leave}}
+    {{else}}
+        {{#if day.color}}
+            style="background: {{day.color}}"
+        {{/if}}
+   {{/if}}
+{{/if}}
+></td>


### PR DESCRIPTION
Exposed color support to the gui. It is working in the team view and the calendar views. 

Still to do (for someone else):
- Replace the input text field for color codes in the admin panel by a color picker
- The color insertion on the model is currently implemented in two places. This should be just one. Couldn't find where though.
- Bug: once you add a new leave type, the colors of all the leave types are reset to #f1f1f1