### PR TITLE
add google authenticator

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -2,6 +2,14 @@
   "allow_create_new_accounts" : true,
   "send_emails"              : false,
   "application_sender_email" : "email@test.com",
+  "login": {
+    "default": false,
+    "google": ["hokify.com"]
+  },
+  "google": {
+    "clientID": "123",
+    "clientSecret": "123"
+  },
   "email_transporter" : {
     "host" : "localhost",
     "port" : 25,

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -91,7 +91,7 @@ function strategy_handler(email, password, strategy, done) {
         };
         break;
       case 'google':
-        authFunction = function({email, done}) {
+        authFunction = function({user, email, done}) {
             let domain;
             domain = email.split("@");
             if(domain && domain.length > 0) {
@@ -117,10 +117,6 @@ function strategy_handler(email, password, strategy, done) {
                 return done("no auth domain");
             }
         };
-          prepare_user_for_session({
-              user : user,
-              done : done,
-          });
       default:
           return done("invalid strategy: " + strategy);
   }

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -176,7 +176,13 @@ module.exports = function(){
           callbackURL: config.get('application_domain') + '/auth/google/callback'
       },
       function(accessToken, refreshToken, profile, cb) {
-          strategy_handler(profile.email, false, 'google', cb);
+          if(profile.emails && profile.emails.length > 0) {
+              const email = profile.emails[0].value;
+              strategy_handler(email, false, 'google', cb);
+          } else {
+              console.error("missing email in google reponse - scope?", profile);
+              cb("no email found");
+          }
       }
   ));
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -104,10 +104,14 @@ function strategy_handler(email, password, strategy, done) {
               // check if valid domain
                 const validDomains = config.get('login').google || false;
                 if(!validDomains) {
+                    console.error("no valid domains");
+
                     return done("no valid domains for google set");
                 }
 
-                if(validDomains.indexOf(domain) !== -1) {
+                if(validDomains.indexOf(domain) == -1) {
+                    console.error("valid domains: ", validDomains, "not valid: ", domain);
+
                     return done("invalid auth domain");
                 }
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -12,8 +12,8 @@
 var model     = require('./model/db'),
 passport      = require('passport'),
 Promise       = require('bluebird'),
-LocalStrategy = require('passport-local').Strategy;
-
+LocalStrategy = require('passport-local').Strategy,
+config         = require('./config');
 // In case if user is successfully logged in, make sure it is
 // activated
 function prepare_user_for_session(args) {
@@ -34,12 +34,8 @@ function prepare_user_for_session(args) {
 // The method is callback based and the result is conveyed
 // via provided callback function "done"
 //
-function authenticate_user(args){
-
-  var user = args.user,
-  password = args.password,
-  done     = args.done,
-  email    = user.email;
+function authenticate_user({user, password, done}){
+  const email    = user.email;
 
   // In case of LDAP authentification connect the LDAP server
   if ( user.company.ldap_auth_enabled ) {
@@ -85,7 +81,49 @@ function authenticate_user(args){
   }
 }
 
-function strategy_handler(email, password, done) {
+function strategy_handler(email, password, strategy, done) {
+
+  let authFunction;
+  switch(strategy) {
+      case 'local':
+        authFunction = function({user, password, done}) {
+            authenticate_user({user, password, done});
+        };
+        break;
+      case 'google':
+        authFunction = function({email, done}) {
+            let domain;
+            domain = email.split("@");
+            if(domain && domain.length > 0) {
+              domain = domain[domain.length-1];
+            } else {
+              domain = false;
+            }
+
+            console.log("domain",domain);
+
+            if(domain) {
+              // check if valid domain
+                const validDomains = config.get('login').google || false;
+                if(!validDomains) {
+                    return done("no valid domains for google set");
+                }
+
+                if(validDomains.indexOf(domain) !== -1) {
+                    return done("invalid auth domain");
+                }
+                authenticate_user({user, password, done});
+            } else {
+                return done("no auth domain");
+            }
+        };
+          prepare_user_for_session({
+              user : user,
+              done : done,
+          });
+      default:
+          return done("invalid strategy: " + strategy);
+  }
 
   // Normalize email to be in lower case
   email = email.toLowerCase();
@@ -112,8 +150,9 @@ function strategy_handler(email, password, done) {
           // We need to have company for user fetchef dow the line so query it now
           user.company = company;
 
-          authenticate_user({
+          authFunction({
             user     : user,
+            email    : email,
             password : password,
             done     : done,
           });
@@ -133,7 +172,21 @@ function strategy_handler(email, password, done) {
 
 module.exports = function(){
 
-  passport.use(new LocalStrategy( strategy_handler ));
+  var GoogleStrategy = require('passport-google-oauth20').Strategy;
+
+  passport.use(new GoogleStrategy({
+          clientID: config.get('google').clientID,
+          clientSecret: config.get('google').clientSecret,
+          callbackURL: config.get('application_domain') + '/auth/google/callback'
+      },
+      function(accessToken, refreshToken, profile, cb) {
+          strategy_handler(profile.email, false, 'google', cb);
+      }
+  ));
+
+  passport.use(new LocalStrategy( function(email, password, done) {
+      strategy_handler(email, password, 'local', done);
+    } ));
 
   // Define how user object is going to be flattered into session
   // after request is processed.

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -100,8 +100,6 @@ function strategy_handler(email, password, strategy, done) {
               domain = false;
             }
 
-            console.log("domain",domain);
-
             if(domain) {
               // check if valid domain
                 const validDomains = config.get('login').google || false;
@@ -112,11 +110,16 @@ function strategy_handler(email, password, strategy, done) {
                 if(validDomains.indexOf(domain) !== -1) {
                     return done("invalid auth domain");
                 }
-                authenticate_user({user, password, done});
+
+                prepare_user_for_session({
+                    user : user,
+                    done : done,
+                });
             } else {
                 return done("no auth domain");
             }
         };
+        break;
       default:
           return done("invalid strategy: " + strategy);
   }

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -44,7 +44,7 @@ module.exports = function(passport) {
   });
 
   router.get('/auth/google',
-    passport.authenticate('google', { scope: ['profile'] }));
+    passport.authenticate('google', { scope: ['profile', 'email'] }));
 
   router.get('/auth/google/callback',
     passport.authenticate('google', { failureRedirect: '/login' }),

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -34,13 +34,24 @@ module.exports = function(passport) {
   var express = require('express');
   var router  = express.Router();
 
-  router.get('/login', function(req, res){
+  router.get('/login', function(req, res) {
       res.render('login', {
+          login: config.get('login') || {default: true},
           allow_create_new_accounts: JSON.parse(config.get('allow_create_new_accounts')),
           title : 'Time Off Management',
           url_to_the_site_root : get_url_to_site_root_for_anonymous_session(req),
       });
   });
+
+  router.get('/auth/google',
+    passport.authenticate('google', { scope: ['profile'] }));
+
+  router.get('/auth/google/callback',
+    passport.authenticate('google', { failureRedirect: '/login' }),
+    function(req, res) {
+        // Successful authentication, redirect home.
+        res.redirect('/');
+    });
 
   router.post('/login', function(req, res, next) {
     passport.authenticate('local', function(err, user, info) {

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -44,7 +44,7 @@ module.exports = function(passport) {
   });
 
   router.get('/auth/google',
-    passport.authenticate('google', { scope: ['profile', 'email'] }));
+    passport.authenticate('google', { scope: ['email'] }));
 
   router.get('/auth/google/callback',
     passport.authenticate('google', { failureRedirect: '/login' }),

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nodemailer-smtp-transport": "^1.1.0",
     "optimist": "^0.6.1",
     "passport": "^0.3.2",
+    "passport-google-oauth20": "^1.0.0",
     "passport-local": "^1.0.0",
     "sequelize": "^3.19.2",
     "sequelize-cli": "2.5.1",

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -5,10 +5,11 @@
 
 {{> show_flash_messages }}
 
-<form class="form-horizontal" action="/login" method="post">
+
+  {{#if login.default}}
+      <form class="form-horizontal" action="/login" method="post">
 
   <div class="row">&nbsp;</div>
-
   <div class="form-group">
     <label for="email_inp" class="col-md-2 control-label col-md-offset-2">Employee email:</label>
     <div class="col-md-5">
@@ -32,7 +33,16 @@
     </div>
   </div>
 
-</form>
+      </form>
+    {{/if}}
+
+    {{#if login.google}}
+        <form action="/auth/google" method="GET">
+            <button type="submit" class="btn btn-default btn-login-google">
+                <span class="provider-logo google"></span> Login with Google
+            </button>
+        </form>
+    {{/if}}
 
 <div class="row">&nbsp;</div>
 


### PR DESCRIPTION
this pr enables login by google auth (via passport).

- it does not create new users, they must be created before hand (the password does not matter in this case though ;))
- you can define which domains are valid - if you have a google work account/domain.
- you can disable the default login
```
"login": {
    "default": false,
    "google": ["yourdomain.com"]
  },
```

you must configure google client id and secret (you get that here: https://console.developers.google.com/apis/credentials)
```
  "google": {
    "clientID": "123",
    "clientSecret": "123"
  },
```

regards
Simon