### PR TITLE
Improved LDAP error handling and explicit parameter for unauthorized SSL certificates

### DIFF
--- a/lib/model/db/company.js
+++ b/lib/model/db/company.js
@@ -370,6 +370,7 @@ module.exports = function(sequelize, DataTypes) {
       get_ldap_server : function(){
 
         var config = this.get('ldap_auth_config');
+        var tlsOptions = config.allow_unauthorized_cert ? { rejectUnauthorized: false } : {};
 
         // When testing consider using TEST LDAP server
         // http://www.forumsys.com/en/tutorials/integration-how-to/ldap/online-ldap-test-server/
@@ -380,6 +381,7 @@ module.exports = function(sequelize, DataTypes) {
           searchBase      : config.searchbase,
           searchFilter    : '(mail={{username}})',
           cache           : false,
+          tlsOptions      : tlsOptions
         });
 
         return ldap;

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -577,9 +577,32 @@ router.post('/company/authentication/', function(req, res){
       company.setDataValue('ldap_auth_enabled', parameters.ldap_auth_enabled);
 
       var ldap_server = company.get_ldap_server();
+      
+      // Handle event based errors from ldapauth-fork
+      var ldapError = "";
+      ldap_server.on('error', function(err) {
+        ldapError = err;
+      });
+      
+      var auth_func = function(email, password) {
+        return new Promise(function(resolve, reject) {
+          // Wait one second before cheking for event based errors
+          setTimeout(() => {
+            if (ldapError) {
+              reject(ldapError);
+            }
+          }, 1000);
 
-      var auth_func = Promise.promisify(ldap_server.authenticate.bind(ldap_server));
-
+          ldap_server.authenticate(email, password, function(error, user) {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(user);
+            }
+          });
+      });
+    };  
+          
       return auth_func(req.user.email, parameters.password_to_check)
         .then(function(){
           return company.save();
@@ -608,7 +631,7 @@ router.post('/company/authentication/', function(req, res){
 
       req.session.flash_error(
         'Failed to update LDAP configuration. ' +
-        ( error.show_to_user ? 'Error: '+error : 'Please contact customer service')
+        ( error.show_to_user ? error : 'Please contact customer service')
       );
 
       return res.redirect_with_session('/settings/company/authentication/');

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -698,11 +698,12 @@ function get_and_validate_ldap_auth_configuration(args) {
 
   // Get parameters
   //
-  var url           = validator.trim(req.param('url')),
-  binddn            = validator.trim(req.param('binddn')),
-  bindcredentials   = validator.trim(req.param('bindcredentials')),
-  searchbase        = validator.trim(req.param('searchbase')),
-  ldap_auth_enabled = validator.toBoolean(req.param('ldap_auth_enabled')),
+  var url                      = validator.trim(req.param('url')),
+  binddn                       = validator.trim(req.param('binddn')),
+  bindcredentials              = validator.trim(req.param('bindcredentials')),
+  searchbase                   = validator.trim(req.param('searchbase')),
+  ldap_auth_enabled            = validator.toBoolean(req.param('ldap_auth_enabled')),
+  allow_unauthorized_cert      = validator.toBoolean(req.param('allow_unauthorized_cert')),
 
   // Fetch the password of current user that is valid in LDAP system
   password_to_check = validator.trim(req.param('password_to_check'));
@@ -724,10 +725,11 @@ function get_and_validate_ldap_auth_configuration(args) {
   // Return the configuration object
   return {
     ldap_config : {
-      url             : url,
-      binddn          : binddn,
-      bindcredentials : bindcredentials,
-      searchbase      : searchbase,
+      url                     : url,
+      binddn                  : binddn,
+      bindcredentials         : bindcredentials,
+      searchbase              : searchbase,
+      allow_unauthorized_cert : allow_unauthorized_cert,
     },
     ldap_auth_enabled : ldap_auth_enabled,
     password_to_check : password_to_check,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "html-to-text": "^3.2.0",
     "ical-generator": "^0.2.7",
     "joi": "~12.0.0",
-    "ldapauth-fork": "^2.5.2",
+    "ldapauth-fork": "^4.0.2",
     "moment": "^2.11.2",
     "moment-timezone": "^0.5.14",
     "morgan": "^1.3.2",

--- a/views/settings_company_authentication.hbs
+++ b/views/settings_company_authentication.hbs
@@ -57,6 +57,17 @@
           <input class="form-control" id="ldap_url" placeholder="ldap://ldap.forumsys.com:389" name="url" value="{{ldap_config.url}}" aria-describedby="ldap_url_help" >
         </div>
         <span id="ldap_url_help" class="help-block">The URL must contain the protocol and port parts</span>
+        <div class="col-md-9 col-md-offset-3">
+          <label for="allow_unauthorized_cert" class="control-label">
+            <input
+              id="allow_unauthorized_cert"
+              type="checkbox"
+              {{# if ldap_config.allow_unauthorized_cert }} checked="checked" {{/if}}
+              name="allow_unauthorized_cert"
+            />&nbsp;
+            Allow unauthorized SSL certificate (if LDAPS is used)
+          </label>
+        </div>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
Hi,

Thanks for an excellent product!

I detected when installing it at our office when using a LDAP-server with a self-signed certificate that the server crashed. After some digging I found that the version of ldapauth-fork used did not handle errors from the ldapjs-module. This was fixed in the new versions. To allow for LDAP errors like the situation when a self-singed certificate is used I bumped the ldapauth-fork to the latest version as well as added error handling for the event based errors.
To allow for self-signed certificates I added a setting on the LDAP-config screen to explicitly allow it.

If you feel this should be handled in a different way let me know and I am very happy to be able to contribute to this great project!

Best regards,
Markus
