### PR TITLE
Allow supervisors to view employees in their dept & revoke leave.

### DIFF
--- a/lib/middleware/ensure_user_is_admin.js
+++ b/lib/middleware/ensure_user_is_admin.js
@@ -15,6 +15,7 @@ module.exports = function(req, res, next){
 
     // Only Admin users allowed to deal with settings pages
     if ( !req.user.is_admin() ) {
+        req.session.flash_error("Permission denied. You must be an admin to do that.")
         return res.redirect_with_session(303, '/');
     }
 

--- a/lib/middleware/ensure_user_is_supervisor.js
+++ b/lib/middleware/ensure_user_is_supervisor.js
@@ -1,0 +1,39 @@
+/*
+ * Midleware that checks if current session has a user and user is a supervisor
+ *
+ * In case of failure - redirects to the route.
+ *
+ * */
+ _ = require('underscore'),
+
+"use strict";
+
+module.exports = function(req, res, next){
+  // console.log(req.user);
+
+  // User should be login to view settings pages
+  if ( !req.user ) {
+      return res.redirect_with_session(303, '/');
+  }
+
+  // Only Supervisors allowed to deal with settings pages. This checks which users
+  // a supervisor can supervise/view/edit - only ones in their department.
+  req.user.promise_users_I_can_manage()
+  .then(function(users){
+    var supervised_users = _.map(
+        users,
+        function(user){ return user.id; }
+    )
+    var userId = Number(req.params.user_id);
+
+    // Take array of users a supervisor can manage, and check if the requested
+    //  user in params.user_id is a user they can supervise, or self, because
+    // supervisors should not be able to supervise themselves, only admin.
+    if (supervised_users.indexOf(userId) < 0 || userId === req.user.id && !req.user.is_admin()) {
+      req.session.flash_error("You need permission to do that. You can't manage yourself, or employees in other departments" );
+      return res.redirect_with_session(303, '/');
+    } else {
+      next();
+    }
+  });
+};

--- a/lib/model/db/user.js
+++ b/lib/model/db/user.js
@@ -229,6 +229,7 @@ function get_instance_methods(sequelize) {
           });
         });
     },
+    
 
     promise_supervised_users : function () {
       let self = this;

--- a/lib/route/users.js
+++ b/lib/route/users.js
@@ -18,9 +18,11 @@ const
   EmailTransport      = require('../email');
 
 // Make sure that current user is authorized to deal with settings
-router.all(/.*/, require('../middleware/ensure_user_is_admin'));
+const ensureUserIsAdmin = require('../middleware/ensure_user_is_admin');
+const ensureUserIsSupervisor = require('../middleware/ensure_user_is_supervisor');
 
-router.get('/add/', function(req, res){
+
+router.get('/add/', ensureUserIsAdmin, function(req, res){
   req.user
     .get_company_for_add_user()
     .then(function(company){
@@ -30,7 +32,7 @@ router.get('/add/', function(req, res){
     });
 });
 
-router.post('/add/', function(req, res){
+router.post('/add/', ensureUserIsAdmin, function(req, res){
 
   const
     model = req.app.get('db_model'),
@@ -108,7 +110,7 @@ router.post('/add/', function(req, res){
   });
 });
 
-router.get('/import/', function(req, res){
+router.get('/import/', ensureUserIsAdmin, function(req, res){
   req.user
     .getCompany()
     .then(company => res.render(
@@ -118,7 +120,7 @@ router.get('/import/', function(req, res){
     ));
 });
 
-router.post('/import/', function(req, res){
+router.post('/import/', ensureUserIsAdmin, function(req, res){
   let
     form = new formidable.IncomingForm(),
     model = req.app.get('db_model'),
@@ -196,7 +198,7 @@ router.post('/import/', function(req, res){
     });
 });
 
-router.post('/import-sample/', function(req, res){
+router.post('/import-sample/', ensureUserIsAdmin, function(req, res){
 
   req.user
     .getCompany({
@@ -223,7 +225,7 @@ router.post('/import-sample/', function(req, res){
 
 });
 
-router.get('/edit/:user_id/', function(req, res){
+router.get('/edit/:user_id/', ensureUserIsSupervisor, function(req, res){
   var user_id = validator.trim(req.param('user_id'));
 
   Promise.try(function(){
@@ -257,7 +259,7 @@ router.get('/edit/:user_id/', function(req, res){
   });
 });
 
-router.get('/edit/:user_id/absences/', function(req, res){
+router.get('/edit/:user_id/absences/', ensureUserIsSupervisor, function(req, res){
   let
     user_id = validator.trim(req.param('user_id')),
     user_allowance;
@@ -348,7 +350,7 @@ router.get('/edit/:user_id/absences/', function(req, res){
 });
 
 
-router.get('/edit/:user_id/schedule/', function(req, res){
+router.get('/edit/:user_id/schedule/', ensureUserIsAdmin, function(req, res){
   var user_id = validator.trim(req.param('user_id'));
 
   Promise.try(function(){
@@ -486,7 +488,7 @@ var ensure_we_are_not_removing_last_admin = function(args){
   return Promise.resolve();
 };
 
-router.post('/edit/:user_id/', function(req, res){
+router.post('/edit/:user_id/', ensureUserIsSupervisor, function(req, res){
   var user_id = validator.trim(req.param('user_id'));
 
   var new_user_attributes,
@@ -590,7 +592,7 @@ router.post('/edit/:user_id/', function(req, res){
 });
 
 
-router.post('/delete/:user_id/', function(req, res){
+router.post('/delete/:user_id/', ensureUserIsAdmin, function(req, res){
     var user_id = validator.trim(req.param('user_id'));
 
     Promise.try(function(){
@@ -630,7 +632,7 @@ router.post('/delete/:user_id/', function(req, res){
 });
 
 
-router.all('/search/', function(req, res){
+router.all('/search/', ensureUserIsAdmin, function(req, res){
 
   // Currently we support search only by email and only JSON type requests
   if ( ! req.accepts('json')) {
@@ -669,7 +671,7 @@ router.all('/search/', function(req, res){
 
 /* Handle the root for users section, it shows the list of all users
  * */
-router.get('/', function(req, res) {
+router.get('/', ensureUserIsAdmin, function(req, res) {
 
     var department_id = req.param('department'),
         users_filter = {},

--- a/views/team_view.hbs
+++ b/views/team_view.hbs
@@ -60,7 +60,7 @@
       <tbody>
       {{# each users_and_leaves}}
         <tr class="teamview-user-list-row" data-vpp-user-list-row={{this.user.id}}>
-          <td class="left-column-cell cross-link">{{# if ../logged_user.admin}} {{#with this.user }}<a href="/users/edit/{{this.id}}/">{{ this.full_name }}</a>{{/with}}  {{else}}{{#with this.user }}<span>{{ this.full_name }}</span>{{/with}}{{/if}}</td>
+          <td class="left-column-cell cross-link">{{# if ../logged_user}} {{#with this.user }}<a href="/users/edit/{{this.id}}/">{{ this.full_name }}</a>{{/with}}  {{else}}{{#with this.user }}<span>{{ this.full_name }}</span>{{/with}}{{/if}}</td>
           <td>
             <span class="teamview-deducted-days"
               {{# if statistics }}


### PR DESCRIPTION
Issue #260 

This is a pretty major change, but one that I've seen that is heavily requested. 

This PR provides supervisors with the ability to view & edit user details within their own department. It only works for users in their own department, that they are supervisors for. They cannot access admin or even themselves. 

It simply gives supervisors access to `users/edit/:id` to be able to cancel/revoke requests that may have been auto-accepted, or where conditions may have changed & need to be changed. And if they wish to edit details of their employees.

I created an `ensure_user_is_supervisor` middleware, similar to your  `ensure_user_is_admin` to check if the current logged-in user is a supervisor and which users they currently manage.

However, as it stands, supervisors can edit their employees information, such as increase their allocated vacation days, or update an email address. That is because of this: 

`router.post('/edit/:user_id/', ensureUserIsSupervisor, function(req, res){`

If the end-user wanted it so that supervisors can view but not edit anything, it would just be a case of switching the middleware in the particular route to `ensureUserIsAdmin` instead. That goes for any functionality they wish to allow/deny for supervisors.

This does not change functionality for regular 'employee' users.