### PR TITLE
Add Employee Comments to Leave Requests

### DIFF
--- a/lib/model/db/leave.js
+++ b/lib/model/db/leave.js
@@ -277,6 +277,22 @@ get_deducted_days : function(args) {
   return leave_days;
 }, // End get_deducted_days
 
+get_employee_comment : function() {
+  if (!this.employee_comment) {
+    return '';
+  } else {
+    return this.employee_comment;
+  }
+},
+
+get_approver_comment : function() {
+  if (!this.approver_comment) {
+    return '';
+  } else {
+    return this.approver_comment;
+  }
+},
+
 promise_to_reject : function(args) {
   let self = this;
 

--- a/lib/model/db/leave.js
+++ b/lib/model/db/leave.js
@@ -295,6 +295,7 @@ get_approver_comment : function() {
 
 promise_to_reject : function(args) {
   let self = this;
+  console.log(args);
 
   if ( ! args ) {
     args = {};

--- a/lib/model/leave/index.js
+++ b/lib/model/leave/index.js
@@ -64,7 +64,8 @@ function createNewLeave(args){
         leaveTypeId      : leave_type.id,
         status           : new_leave_status,
         approverId       : main_supervisor.id,
-        employee_comment : valide_attributes.reason,
+        employee_comment : valide_attributes.employee_comment,
+        approver_comment : valide_attributes.approver_comment,
 
         date_start     : start_date.format('YYYY-MM-DD'),
         date_end       : end_date.format('YYYY-MM-DD'),

--- a/lib/model/leave_request_parameters.js
+++ b/lib/model/leave_request_parameters.js
@@ -13,7 +13,7 @@ function LeaveRequest(args) {
     _.each(
         [
           'leave_type','from_date','from_date_part',
-          'to_date', 'to_date_part', 'reason'
+          'to_date', 'to_date_part', 'employee_comment'
         ],
         function(property){
             if (! _.has(args, property)) {
@@ -30,7 +30,7 @@ function LeaveRequest(args) {
     _.each(
         [
           'leave_type','from_date','from_date_part',
-          'to_date', 'to_date_part', 'reason', 'user'
+          'to_date', 'to_date_part', 'employee_comment', 'user'
         ],
         function(property){ me[property] = args[property]; }
     );
@@ -43,7 +43,7 @@ LeaveRequest.prototype.as_data_object = function(){
     _.each(
         [
           'leave_type','from_date','from_date_part',
-          'to_date', 'to_date_part', 'reason', 'user'
+          'to_date', 'to_date_part', 'employee_comment', 'user'
         ],
         function(property){ obj[property] = me[property]; }
     );

--- a/lib/route/validator/leave_request.js
+++ b/lib/route/validator/leave_request.js
@@ -8,13 +8,13 @@ var validator = require('validator'),
 module.exports = function(args){
     var req = args.req;
 
-    var user           = validator.trim( req.param('user') ),
-        leave_type     = validator.trim( req.param('leave_type') ),
-        from_date      = validator.trim( req.param('from_date') ),
-        from_date_part = validator.trim( req.param('from_date_part') ),
-        to_date        = validator.trim( req.param('to_date') ),
-        to_date_part   = validator.trim( req.param('to_date_part') ),
-        reason         = validator.trim( req.param('reason') );
+    var user             = validator.trim( req.param('user') ),
+        leave_type       = validator.trim( req.param('leave_type') ),
+        from_date        = validator.trim( req.param('from_date') ),
+        from_date_part   = validator.trim( req.param('from_date_part') ),
+        to_date          = validator.trim( req.param('to_date') ),
+        to_date_part     = validator.trim( req.param('to_date_part') ),
+        employee_comment = validator.trim( req.param('employee_comment') );
 
     if (user && !validator.isNumeric(user)){
         req.session.flash_error('Incorrect employee');
@@ -70,12 +70,12 @@ module.exports = function(args){
     }
 
     var valid_attributes = {
-        leave_type     : leave_type,
-        from_date      : from_date,
-        from_date_part : from_date_part,
-        to_date        : to_date,
-        to_date_part   : to_date_part,
-        reason         : reason,
+        leave_type       : leave_type,
+        from_date        : from_date,
+        from_date_part   : from_date_part,
+        to_date          : to_date,
+        to_date_part     : to_date_part,
+        employee_comment : employee_comment,
     };
 
     if ( user ) {

--- a/t/unit/model/db/leave.js
+++ b/t/unit/model/db/leave.js
@@ -23,11 +23,11 @@ describe('Check bug when type mismatch happenned', function(){
                     from_date      : '2015-05-07',
                     from_date_part : '2',
                     to_date        : '2015-05-07',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 2,
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.equal(false);
@@ -51,11 +51,11 @@ describe('leave request half a day with existing booking of half a day', functio
                     from_date      : '2015-04-09',
                     from_date_part : 2,
                     to_date        : '2015-04-09',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -68,11 +68,11 @@ describe('leave request half a day with existing booking of half a day', functio
                     from_date      : '2015-04-09',
                     from_date_part : 3,
                     to_date        : '2015-04-09',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.ok;
@@ -102,10 +102,10 @@ describe('Leave request is spread through more then one day', function(){
                     from_date_part : 1,
                     to_date        : '2015-04-09',
                     to_date_part   : 1,
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -119,10 +119,10 @@ describe('Leave request is spread through more then one day', function(){
                     from_date_part : 1,
                     to_date        : '2015-04-11',
                     to_date_part   : 1,
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -136,10 +136,10 @@ describe('Leave request is spread through more then one day', function(){
                     from_date_part : 1,
                     to_date        : '2015-04-09',
                     to_date_part   : 3,
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
-                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.ok;

--- a/t/unit/model/db/leave.js
+++ b/t/unit/model/db/leave.js
@@ -13,6 +13,7 @@ describe('Check bug when type mismatch happenned', function(){
         day_part_start : 2,
         date_end     : '2015-05-07 00:00:00.000 +00:00',
         day_part_end : 2,
+        employee_comment : 'Employee comment',
     });
 
     it('String value of 2 properly used', function(){
@@ -26,6 +27,7 @@ describe('Check bug when type mismatch happenned', function(){
                     to_date_part : 2,
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.equal(false);
@@ -39,6 +41,7 @@ describe('leave request half a day with existing booking of half a day', functio
         date_end : '2015-04-09',
         day_part_start : 2,
         day_part_end : 2,
+        employee_comment : 'Employee comment',
     });
 
     it('clash', function(){
@@ -52,6 +55,7 @@ describe('leave request half a day with existing booking of half a day', functio
                     to_date_part : 1,
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -68,6 +72,7 @@ describe('leave request half a day with existing booking of half a day', functio
                     to_date_part : 1,
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.ok;
@@ -82,6 +87,7 @@ describe('Leave request is spread through more then one day', function(){
         date_end       : '2015-04-10',
         day_part_start : 2,
         day_part_end   : 1,
+        employee_comment : 'Employee comment',
     });
 
     it('leave object is instanciated', function(){
@@ -99,6 +105,7 @@ describe('Leave request is spread through more then one day', function(){
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -115,6 +122,7 @@ describe('Leave request is spread through more then one day', function(){
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.not.be.ok;
@@ -131,6 +139,7 @@ describe('Leave request is spread through more then one day', function(){
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
+                    employee_comment : 'Employee comment',
                 })
             )
         ).to.be.ok;
@@ -144,6 +153,7 @@ describe('Leave request is spread through more then one day', function(){
                     from_date_part : 1,
                     to_date        : '2015-04-09',
                     to_date_part   : 2,
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
@@ -160,6 +170,7 @@ describe('Leave request is spread through more then one day', function(){
                     from_date_part : 2,
                     to_date        : '2015-04-11',
                     to_date_part   : 1,
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     leave_type   : 1,
                     reason       : 1,
@@ -178,6 +189,7 @@ describe('Case when leave request is within one day', function(){
         date_end       : '2015-04-10',
         day_part_start : 2,
         day_part_end   : 1,
+        employee_comment : 'Employee comment',
     });
 
     it('Is half and attempt to stick to the half day part so they fit', function(){
@@ -187,6 +199,7 @@ describe('Case when leave request is within one day', function(){
                     from_date      : '2015-04-09',
                     from_date_part : 3,
                     to_date        : '2015-04-09',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
@@ -203,6 +216,7 @@ describe('Case when leave request is within one day', function(){
                     from_date      : '2015-04-09',
                     from_date_part : 2,
                     to_date        : '2015-04-09',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
@@ -219,6 +233,7 @@ describe('Case when leave request is within one day', function(){
                     from_date      : '2015-04-10',
                     from_date_part : 2,
                     to_date        : '2015-04-10',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
@@ -235,6 +250,7 @@ describe('Case when leave request is within one day', function(){
                     from_date      : '2015-04-09',
                     from_date_part : 1,
                     to_date        : '2015-04-09',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,
@@ -251,6 +267,7 @@ describe('Case when leave request is within one day', function(){
                     from_date      : '2015-04-10',
                     from_date_part : 1,
                     to_date        : '2015-04-10',
+                    employee_comment : 'Employee comment',
                     // do not care about following parameters
                     to_date_part : 1,
                     leave_type   : 1,

--- a/t/unit/validator/leave_request.js
+++ b/t/unit/validator/leave_request.js
@@ -46,7 +46,7 @@ describe('Check validation for leave request', function(){
         from_date_part : '1',
         to_date        : '2015-05-12',
         to_date_part   : '2',
-        reason         : 'some reason',
+        employee_comment : 'employee comment',
     };
 
 
@@ -137,12 +137,12 @@ describe('Check validation for leave request', function(){
     });
 
 
-    it('Reason is optional', function(){
+    it('Employee comment is optional', function(){
 
         var params = _.clone( valid_params );
-        delete params.reason;
+        delete params.employee_comment;
         var vp = _.clone( valid_params );
-        vp.reason = '';
+        vp.employee_comment = '';
         var req = new MockExpressReq({params : params});
 
         expect(

--- a/views/partials/book_leave_modal.hbs
+++ b/views/partials/book_leave_modal.hbs
@@ -67,6 +67,11 @@
             </div>
           </div>
 
+          <div class="form-group">
+            <label for="leave_type" class="control-label">Enter A Comment:</label>
+            <textarea class="form-control" rows="4" name="employee_comment" id="employee_comment" placeholder="Enter text here..."></textarea></textarea>
+          </div>
+
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
@@ -81,5 +86,3 @@
     </div>
   </div>
 </div>
-
-

--- a/views/partials/user_requests.hbs
+++ b/views/partials/user_requests.hbs
@@ -18,6 +18,8 @@
           <th>Approved by</th>
           <th></th>
           <th><span class="pull-right">Status</span></th>
+          <th>Employee Comment</th>
+          <th>Supervisor Comment</th>
         </tr>
       </thead>
 
@@ -47,6 +49,7 @@
           {{/if}}
         </td>
         <td><span class="pull-right leave-request-row-status">{{#if this.is_new_leave }}Pending{{else}}{{#if this.is_approved_leave}}Approved{{else}}Rejected{{/if}}{{/if}}</span></td>
+        <td>{{#if this.get_employee_comment}}{{this.get_employee_comment}}{{/if}}</td>
       </tr>
 
       {{/ each }}

--- a/views/partials/user_requests.hbs
+++ b/views/partials/user_requests.hbs
@@ -19,7 +19,6 @@
           <th></th>
           <th><span class="pull-right">Status</span></th>
           <th>Employee Comment</th>
-          <th>Supervisor Comment</th>
         </tr>
       </thead>
 

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -53,6 +53,7 @@
                   console.log("APPROVER COMMENT: " + approverComment);
                   location = "requests/reject/";
                 }
+                return approverComment;
               }
             </script>
           </td>

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -27,6 +27,7 @@
           <th>Leave dates</th>
           <th>Type</th>
           <th>Days</th>
+          <th>Employee Comment</th>
           <th colspan="2"></th>
         </tr>
       </thead>
@@ -39,11 +40,21 @@
           <td data-tom-leave-dates="1">{{> leave_dates leave=this}}</td>
           <td>{{#if this.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leave_type.name}}</td>
           <td data-vpp="days_used">{{ this.get_deducted_days_number }}</td>
+          <td>{{#if this.get_employee_comment}}{{this.get_employee_comment}}{{/if}}</td>
           <td>
             <form action="/requests/reject/" method="POST">
-            <input class="btn btn-warning" type="submit" value="Reject">
+            <input class="btn btn-warning" onclick="commentHandler(this)" type="submit" value="Reject">
             <input type="hidden" value="{{this.id}}" name="request">
             </form>
+            <script>
+              var commentHandler = function(event) {
+              var approverComment = prompt("Would you like to enter an explanation?","Enter text here...");
+                if (approverComment !== "" && approverComment !== "Enter text here...") {
+                  console.log("APPROVER COMMENT: " + approverComment);
+                  location = "requests/reject/";
+                }
+              }
+            </script>
           </td>
           <td>
             <form action="/requests/approve/" method="POST">


### PR DESCRIPTION
Issue #133 

This half-fixes issue #133 - allowing comments to be included on leave requests. However, this only allows for one half of that - allowing employee's to include comments as part of their leave request. This comment then appears on all corresponding views for both the employee and approving manager.

I wasn't sure how you wanted to deal with the user flow of the supervisor adding an approval/rejection message in response. I originally had it with a JavaScript prompt popping up and allowing them to type their response there, but it felt a little... clunky? So, I've left it at this for now.

I have also updated all tests to allow for this change. 