### PR TITLE
Fixes issue #294, allowing all valid TLDs in emails.

### DIFF
--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -103,7 +103,7 @@ module.exports = function(passport) {
       // TODO at some point we need to unified form validation code
       // and make it reusable
 
-      var email_validation_re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+      var email_validation_re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]*(?:\.[a-z]{2})?)$/i;
 
       var email = req.param('email');
       if (!email){


### PR DESCRIPTION
There are plenty of totally valid TLDs now that have more than 6 characters but the email validation regex does not agree.

At some point a proper validator that can reference the canonical ICANN TLD list would be prudent but for now I think this change does not hurt the validation but allows all valid TLDs to be used.