### PR TITLE
Use a better email validator when registering

### DIFF
--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -103,12 +103,10 @@ module.exports = function(passport) {
       // TODO at some point we need to unified form validation code
       // and make it reusable
 
-      var email_validation_re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
-
       var email = req.param('email');
       if (!email){
           req.session.flash_error('Email was not provided');
-      } else if ( ! email_validation_re.test( email )) {
+      } else if ( ! validator.isEmail(email)) {
           req.session.flash_error('Email address is invalid');
       }
 


### PR DESCRIPTION
The email validator used when registering a new company uses a regular expression that doesn't allow "modern" valid email addresses, such as the ones form newer, longer top-level domain names.

This change makes it use the same email validator as the one used in the password reset form, which correctly allows these longer domain names.