### PR TITLE
fix: npm test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "selenium-webdriver": "2.53.3"
   },
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --recursive t/*",
+    "test": "node node_modules/mocha/bin/mocha --recursive t",
     "start": "node bin/wwww",
     "db-update": "node node_modules/.bin/sequelize db:migrate --config=config/db.json --models-path=lib/model/db/",
     "carry-over-allowance": "node bin/calculate_carry_over_allowance_for_all_users.js",


### PR DESCRIPTION
It seems that the issue #344 with `npm test` on Windows is due to the * at the end of the command (which does not seem necessary). 