### PR TITLE
Configurable LDAP search filter. Issue #352

### DIFF
--- a/lib/model/db/company.js
+++ b/lib/model/db/company.js
@@ -313,7 +313,7 @@ module.exports = function(sequelize, DataTypes) {
           bindDn          : config.binddn,
           bindCredentials : config.bindcredentials,
           searchBase      : config.searchbase,
-          searchFilter    : '(mail={{username}})',
+          searchFilter    : config.searchfilter,
           cache           : false,
           tlsOptions      : tlsOptions
         });

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -784,6 +784,7 @@ function get_and_validate_ldap_auth_configuration(args) {
   binddn                       = validator.trim(req.param('binddn')),
   bindcredentials              = validator.trim(req.param('bindcredentials')),
   searchbase                   = validator.trim(req.param('searchbase')),
+  searchfilter                 = validator.trim(req.param('searchfilter')),
   ldap_auth_enabled            = validator.toBoolean(req.param('ldap_auth_enabled')),
   allow_unauthorized_cert      = validator.toBoolean(req.param('allow_unauthorized_cert')),
 
@@ -795,6 +796,12 @@ function get_and_validate_ldap_auth_configuration(args) {
   if (!validator.matches(url, /^ldaps?:\/\/[a-z0-9\.\-]+:\d+$/i)){
     req.session.flash_error(
       "URL to LDAP server must be of following format: 'ldap://HOSTNAME:PORT'"
+    );
+  }
+
+  if (!validator.matches(url, /\{\{username\}\}/)){
+    req.session.flash_error(
+      "LDAP filter must contain {{username}} variable. Use '(mail={{username}})' to match mail as the username."
     );
   }
 
@@ -811,6 +818,7 @@ function get_and_validate_ldap_auth_configuration(args) {
       binddn                  : binddn,
       bindcredentials         : bindcredentials,
       searchbase              : searchbase,
+      searchfilter            : searchfilter,
       allow_unauthorized_cert : allow_unauthorized_cert,
     },
     ldap_auth_enabled : ldap_auth_enabled,

--- a/views/settings_company_authentication.hbs
+++ b/views/settings_company_authentication.hbs
@@ -92,6 +92,13 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label for="ldap_search_filter" class="col-md-3 control-label">Search Filter</label>
+        <div class="col-md-5">
+          <input class="form-control" id="ldap_search_filter" placeholder="(mail={{username}})" name="searchfilter" value="{{ ldap_config.searchfilter }}">
+        </div>
+      </div>
+
       <hr/>
 
       <p class="col-md-offset-2">In order to prevent a situation where a company account locks itself out, the current administrator (<strong>{{# with logged_user}}{{this.full_name}}{{/with}}</strong>) has to enter the password associated with her/his email on the LDAP server.</p>


### PR DESCRIPTION
This patch removes the hard-coded LDAP search filter and adds a new field _searchfilter_ in the _ldap_auth_config_ configuration object.

Not yet tested at the moment. Please, validate before merging...