### PR TITLE
fix: improve misleading email object for leave request decision

### DIFF
--- a/views/email/leave_request_decision_to_requestor.hbs
+++ b/views/email/leave_request_decision_to_requestor.hbs
@@ -1,4 +1,4 @@
-Leave request was decided
+Leave request was {{#if_equal action 'approve'}}accepted{{else}}denied{{/if_equal}}
 =====
 <p>Hello <strong>{{#with requester}}{{this.full_name}}{{/with}}</strong>,</p>
 


### PR DESCRIPTION
This fixes #333 improving the email object sent to the requestor after decision.