### PR TITLE
fix: replace deprecated express req.param

### DIFF
--- a/lib/route/audit.js
+++ b/lib/route/audit.js
@@ -14,10 +14,10 @@ router.all(/.*/, require('../middleware/ensure_user_is_admin'));
 
 router.get(/email/, function(req, res){
 
-  var user_id = validator.toInt(req.param('user_id')),
-  start_date  = validator.trim(req.param('start_date')),
-  end_date    = validator.trim(req.param('end_date')),
-  page        = validator.toInt(req.param('page')) || 1,
+  var user_id = validator.toInt(req.query['user_id']),
+  start_date  = validator.trim(req.query['start_date']),
+  end_date    = validator.trim(req.query['end_date']),
+  page        = validator.toInt(req.query['page']) || 1,
   model       = req.app.get('db_model'),
   filter      = {
     company_id: req.user.companyId,

--- a/lib/route/calendar.js
+++ b/lib/route/calendar.js
@@ -56,8 +56,8 @@ router.post('/bookleave/', function(req, res){
 
         req.session.flash_message('New leave request was added');
         return res.redirect_with_session(
-          req.param('redirect_back_to')
-            ? req.param('redirect_back_to')
+          req.body['redirect_back_to']
+            ? req.body['redirect_back_to']
             : '../'
         );
     })
@@ -73,8 +73,8 @@ router.post('/bookleave/', function(req, res){
             req.session.flash_error(error.user_message);
         }
         return res.redirect_with_session(
-          req.param('redirect_back_to')
-            ? req.param('redirect_back_to')
+          req.body['redirect_back_to']
+            ? req.body['redirect_back_to']
             : '../'
         );
     });
@@ -83,11 +83,11 @@ router.post('/bookleave/', function(req, res){
 
 router.get('/', function(req, res) {
 
-  var current_year = validator.isNumeric(req.param('year'))
-    ? moment.utc(req.param('year'), 'YYYY')
+  var current_year = validator.isNumeric(req.query['year'])
+    ? moment.utc(req.query['year'], 'YYYY')
     : req.user.company.get_today();
 
-  var show_full_year = validator.toBoolean(req.param('show_full_year'));
+  var show_full_year = validator.toBoolean(req.query['show_full_year']);
 
   Promise.join(
     req.user.promise_calendar({
@@ -128,8 +128,8 @@ router.get('/teamview/', function(req, res){
     return res.redirect_with_session('/');
   }
 
-  const base_date = validator.isDate(req.param('date'))
-    ? moment.utc(req.param('date'))
+  const base_date = validator.isDate(req.query['date'])
+    ? moment.utc(req.query['date'])
     : req.user.company.get_today();
 
   const team_view = new TeamView({
@@ -137,8 +137,8 @@ router.get('/teamview/', function(req, res){
     user      : req.user,
   });
 
-  const current_deparment_id  = validator.isNumeric(req.param('department'))
-    ? req.param('department')
+  const current_deparment_id  = validator.isNumeric(req.query['department'])
+    ? req.query['department']
     : null;
 
   Promise.join(
@@ -209,7 +209,7 @@ router.post('/feeds/regenerate/', function(req, res){
   req.user
     .getFeeds()
     .then(function(feeds){
-      var the_feed = _.findWhere(feeds, { feed_token : req.param('token') });
+      var the_feed = _.findWhere(feeds, { feed_token : req.body['token'] });
 
       if (the_feed) {
 

--- a/lib/route/departments.js
+++ b/lib/route/departments.js
@@ -35,14 +35,14 @@ function get_and_validate_department(args) {
 
   // Get user parameters
   let
-    name      = validator.trim(req.param(no_suffix ? 'name'      : 'name__'+index)),
-    allowance = validator.trim(req.param(no_suffix ? 'allowance' : 'allowance__'+index)),
-    boss_id   = validator.trim(req.param(no_suffix ? 'boss_id'   : 'boss_id__'+index)),
+    name      = validator.trim(req.body[no_suffix ? 'name'      : 'name__'+index]),
+    allowance = validator.trim(req.body[no_suffix ? 'allowance' : 'allowance__'+index]),
+    boss_id   = validator.trim(req.body[no_suffix ? 'boss_id'   : 'boss_id__'+index]),
     include_public_holidays = validator.toBoolean(
-      req.param(no_suffix ? 'include_public_holidays' : 'include_public_holidays__'+index)
+      req.body[no_suffix ? 'include_public_holidays' : 'include_public_holidays__'+index]
     ),
     is_accrued_allowance = validator.toBoolean(
-      req.param(no_suffix ? 'is_accrued_allowance' : 'is_accrued_allowance__'+index)
+      req.body[no_suffix ? 'is_accrued_allowance' : 'is_accrued_allowance__'+index]
     );
 
   // Validate provided parameters
@@ -158,7 +158,7 @@ router.post('/departments/', function(req, res){
 
 router.post('/departments/delete/:department_id/', function(req, res){
 
-  var department_id = req.param('department_id'),
+  var department_id = req.params['department_id'],
     department_to_remove;
 
   if (!validator.isInt(department_id)) {
@@ -225,7 +225,7 @@ router.post('/departments/delete/:department_id/', function(req, res){
 });
 
 function promise_to_extract_company_and_department(req, only_active = true) {
-  var department_id = req.param('department_id'),
+  var department_id = req.params['department_id'],
     company;
 
   return Promise.try(function(){
@@ -274,7 +274,7 @@ function promise_to_extract_company_and_department(req, only_active = true) {
 }
 
 router.get('/departments/edit/:department_id/', function(req, res){
-  var department_id = req.param('department_id');
+  var department_id = req.params['department_id'];
 
   Promise.try(function(){
     return promise_to_extract_company_and_department(req);
@@ -306,7 +306,7 @@ router.get('/departments/edit/:department_id/', function(req, res){
 
 router.post('/departments/edit/:department_id/', function(req, res){
 
-  var department_id = req.body['department_id'],
+  var department_id = req.params['department_id'],
     company,
     department;
 
@@ -446,7 +446,7 @@ function promise_to_update_department(args) {
 
 router.get('/departments/available-supervisors/:department_id/', function(req, res){
 
-  var department_id = req.param('department_id'),
+  var department_id = req.params['department_id'],
     department,
     company;
 

--- a/lib/route/feed.js
+++ b/lib/route/feed.js
@@ -20,7 +20,7 @@ router.get('/:token/ical.ics', function(req, res){
   var cal = ical({
       domain : 'timeoff.management',
     }),
-    token = req.param('token'),
+    token = req.params['token'],
     model = req.app.get('db_model'),
     user;
 

--- a/lib/route/integration_api.js
+++ b/lib/route/integration_api.js
@@ -36,12 +36,12 @@ module.exports = passport => {
     '/report/allowance',
     (req, res) => {
 
-      const startDate = validator.isDate(req.param('start_date'))
-        ? moment.utc(req.param('start_date'))
+      const startDate = validator.isDate(req.query['start_date'])
+        ? moment.utc(req.query['start_date'])
         : req.user.company.get_today();
 
-      const endDate = validator.isDate(req.param('end_date'))
-        ? moment.utc(req.param('end_date'))
+      const endDate = validator.isDate(req.query['end_date'])
+        ? moment.utc(req.query['end_date'])
         : req.user.company.get_today();
 
       const teamView = new TeamView({
@@ -50,8 +50,8 @@ module.exports = passport => {
         end_date   : endDate,
       });
 
-      const currentDeparmentId  = validator.isNumeric(req.param('department'))
-        ? req.param('department')
+      const currentDeparmentId  = validator.isNumeric(req.query['department'])
+        ? req.query['department']
         : null;
 
       Promise.join(
@@ -94,16 +94,16 @@ module.exports = passport => {
     '/report/absence',
     (req,res) => {
 
-      const startDate = validator.isDate(req.param('start_date'))
-        ? moment.utc(req.param('start_date'))
+      const startDate = validator.isDate(req.query['start_date'])
+        ? moment.utc(req.query['start_date'])
         : req.user.company.get_today();
 
-      const endDate = validator.isDate(req.param('end_date'))
-        ? moment.utc(req.param('end_date'))
+      const endDate = validator.isDate(req.query['end_date'])
+        ? moment.utc(req.query['end_date'])
         : req.user.company.get_today();
 
-      const departmentId  = validator.isNumeric(req.param('department'))
-        ? req.param('department')
+      const departmentId  = validator.isNumeric(req.query['department'])
+        ? req.query['department']
         : null;
 
       let result = getUsersWithLeaves({company:req.user.company, startDate, endDate, departmentId});

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -103,38 +103,38 @@ module.exports = function(passport) {
       // TODO at some point we need to unified form validation code
       // and make it reusable
 
-      var email = req.param('email');
+      var email = req.body['email'];
       if (!email){
           req.session.flash_error('Email was not provided');
       } else if ( ! validator.isEmail(email)) {
           req.session.flash_error('Email address is invalid');
       }
 
-      var name = req.param('name');
+      var name = req.body['name'];
       if (!name){
           req.session.flash_error('Name was not specified');
       }
 
-      var lastname = req.param('lastname');
+      var lastname = req.body['lastname'];
       if (!lastname) {
           req.session.flash_error('Last was not specified');
       }
 
-      var company_name = req.param('company_name');
+      var company_name = req.body['company_name'];
 
-      var password = req.param('password');
+      var password = req.body['password'];
       if (!password) {
           req.session.flash_error('Password could not be blank');
-      } else if ( password !== req.param('password_confirmed') ) {
+      } else if ( password !== req.body['password_confirmed'] ) {
           req.session.flash_error('Confirmed password does not match initial one');
       }
 
-      var country_code = req.param('country');
+      var country_code = req.body['country'];
       if (! validator.matches(country_code, /^[a-z]{2}/i) ){
           req.session.flash_error('Incorrect country code');
       }
 
-      let timezone = validator.trim(req.param('timezone'));
+      let timezone = validator.trim(req.body['timezone']);
       if ( ! moment_tz.tz.names().find(tz_str => tz_str === timezone) ) {
         req.session.flash_error('Time zone is unknown');
       }
@@ -203,7 +203,7 @@ module.exports = function(passport) {
   });
 
   router.post('/forgot-password/', function(req, res){
-    var email = req.param('email');
+    var email = req.body['email'];
 
     if (!email){
       req.session.flash_error('Email was not provided');
@@ -261,7 +261,7 @@ module.exports = function(passport) {
 
   router.get('/reset-password/', function(req, res){
 
-    var token = req.param('t');
+    var token = req.body['t'];
 
     req.app.get('db_model').User.get_user_by_reset_password_token(token)
       .then(function(user){
@@ -279,9 +279,9 @@ module.exports = function(passport) {
 
   router.post('/reset-password/', function(req, res){
 
-    var token        = req.param('t'),
-    password         = req.param('password'),
-    confirm_password = req.param('confirm_password');
+    var token        = req.body['t'],
+    password         = req.body['password'],
+    confirm_password = req.body['confirm_password'];
 
 
     if (password !== confirm_password) {

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -261,7 +261,7 @@ module.exports = function(passport) {
 
   router.get('/reset-password/', function(req, res){
 
-    var token = req.body['t'];
+    var token = req.query['t'];
 
     req.app.get('db_model').User.get_user_by_reset_password_token(token)
       .then(function(user){

--- a/lib/route/reports.js
+++ b/lib/route/reports.js
@@ -22,12 +22,12 @@ router.get('/', (req, res) => {
 
 router.get('/allowancebytime/', (req, res) => {
 
-  let start_date = validator.isDate(req.param('start_date'))
-    ? moment.utc(req.param('start_date'))
+  let start_date = validator.isDate(req.query['start_date'])
+    ? moment.utc(req.query['start_date'])
     : req.user.company.get_today();
 
-  let end_date = validator.isDate(req.param('end_date'))
-    ? moment.utc(req.param('end_date'))
+  let end_date = validator.isDate(req.query['end_date'])
+    ? moment.utc(req.query['end_date'])
     : req.user.company.get_today();
 
   var team_view = new TeamView({
@@ -36,8 +36,8 @@ router.get('/allowancebytime/', (req, res) => {
     end_date   : end_date,
   });
 
-  var current_deparment_id  = validator.isNumeric(req.param('department'))
-    ? req.param('department')
+  var current_deparment_id  = validator.isNumeric(req.query['department'])
+    ? req.query['department']
     : null;
 
   Promise.join(
@@ -95,7 +95,7 @@ function render_allowancebytime(args) {
     end_date          = args.end_date;
 
     return Promise
-      .try(() => req.param('as-csv')
+      .try(() => req.query['as-csv']
         ? render_allowancebytime_as_csv(args)
         : res.render('report/allowancebytime', {
           users_and_leaves    : team_view_details.users_and_leaves,

--- a/lib/route/requests.js
+++ b/lib/route/requests.js
@@ -35,7 +35,7 @@ function leave_request_action(args) {
 
     return function(req, res){
 
-    var request_id = validator.trim( req.param('request') );
+    var request_id = validator.trim( req.body['request'] );
 
     if (!validator.isNumeric(request_id)){
       req.session.flash_error('Failed to ' + current_action);
@@ -124,7 +124,7 @@ router.post(
 
 router.post('/cancel/', function(req, res){
 
-  var request_id = validator.trim( req.param('request') );
+  var request_id = validator.trim( req.body['request'] );
 
   Promise.try(function(){
     return req.user.promise_cancelable_leaves()
@@ -179,7 +179,7 @@ router.post('/cancel/', function(req, res){
 router.post(
   '/revoke/',
   function(req, res){
-    var request_id = validator.trim( req.param('request') );
+    var request_id = validator.trim( req.body['request'] );
 
     // TODO NOTE revoke action now could be made from more then one place,
     // so make sure that user is redirected to correct place

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -69,16 +69,16 @@ router.get('/general/', function(req, res){
 router.post('/company/', function(req, res){
 
   const
-    name              = validator.trim(req.param('name')),
-    country_code      = validator.trim(req.param('country')),
-    date_format       = validator.trim(req.param('date_format')),
-    timezone          = validator.trim(req.param('timezone')),
-    carriedOverDays   = validator.trim(req.param('carry_over')),
+    name              = validator.trim(req.body['name']),
+    country_code      = validator.trim(req.body['country']),
+    date_format       = validator.trim(req.body['date_format']),
+    timezone          = validator.trim(req.body['timezone']),
+    carriedOverDays   = validator.trim(req.body['carry_over']),
     share_all_absences= validator.toBoolean(
-      req.param('share_all_absences')
+      req.body['share_all_absences']
     ),
     isTeamViewHidden = validator.toBoolean(
-      req.param('is_team_view_hidden')
+      req.body['is_team_view_hidden']
     );
 
   if (!validator.isAlphanumeric(country_code)){
@@ -247,8 +247,8 @@ router.post('/schedule/', function(req, res){
 });
 
 router.post('/bankholidays/', function(req,res){
-    var name = validator.trim(req.param('name')),
-        date = validator.trim(req.param('date')),
+    var name = validator.trim(req.body['name']),
+        date = validator.trim(req.body['date']),
         model= req.app.get('db_model');
 
     req.user.getCompany({
@@ -259,7 +259,7 @@ router.post('/bankholidays/', function(req,res){
 
         var promise_new_bank_holiday = Promise.resolve(1);
 
-        if (validator.trim(req.param('name__new'))) {
+        if (validator.trim(req.body['name__new'])) {
             var attributes = get_and_validate_bank_holiday({
                 req       : req,
                 suffix    : 'new',
@@ -392,7 +392,7 @@ router.post('/bankholidays/delete/:bank_holiday_number/', function(req, res){
 
     // bank_holiday_number is a index number of bank_holiday to be removed based
     // on the list of bank holidays on the page, this is not an ID
-    var bank_holiday_number = req.param('bank_holiday_number');
+    var bank_holiday_number = req.params['bank_holiday_number'];
 
     var model = req.app.get('db_model');
 
@@ -446,7 +446,7 @@ router.post('/leavetypes', function(req, res){
 
       var promise_new_leave_type = Promise.resolve(1);
 
-      if (validator.trim(req.param('name__new'))) {
+      if (validator.trim(req.body['name__new'])) {
         var attributes = get_and_validate_leave_type({
           req       : req,
           suffix    : 'new',
@@ -502,7 +502,7 @@ router.post('/leavetypes', function(req, res){
 
 router.post('/leavetypes/delete/:leave_type_id/', function(req, res){
 
-    var leave_type_id = req.param('leave_type_id');
+    var leave_type_id = req.params['leave_type_id'];
 
     var model = req.app.get('db_model');
 
@@ -703,8 +703,8 @@ function get_and_validate_bank_holiday(args) {
       item_name = args.item_name;
 
   // Get user parameters
-  var name = validator.trim(req.param('name__'+index)),
-      date = validator.trim(req.param('date__'+index));
+  var name = validator.trim(req.body['name__'+index]),
+      date = validator.trim(req.body['date__'+index]);
 
   // Validate provided parameters
   //
@@ -733,12 +733,12 @@ function get_and_validate_leave_type(args) {
 
   // Get user parameters
   let
-    name          = validator.trim(req.param('name__'+suffix)),
-    color        = validator.trim(req.param('color__'+suffix)) || 'leave_type_color_1',
-    limit        = validator.trim(req.param('limit__'+suffix)) || 0,
-    first_record = validator.trim(req.param('first_record'))   || 0,
+    name          = validator.trim(req.body['name__'+suffix]),
+    color        = validator.trim(req.body['color__'+suffix]) || 'leave_type_color_1',
+    limit        = validator.trim(req.body['limit__'+suffix]) || 0,
+    first_record = validator.trim(req.body['first_record'])   || 0,
     use_allowance = validator.toBoolean(
-      req.param('use_allowance__'+suffix)
+      req.body['use_allowance__'+suffix]
     );
 
   // If no name for leave type was provided: do nothing - treat case
@@ -780,15 +780,15 @@ function get_and_validate_ldap_auth_configuration(args) {
 
   // Get parameters
   //
-  var url                      = validator.trim(req.param('url')),
-  binddn                       = validator.trim(req.param('binddn')),
-  bindcredentials              = validator.trim(req.param('bindcredentials')),
-  searchbase                   = validator.trim(req.param('searchbase')),
-  ldap_auth_enabled            = validator.toBoolean(req.param('ldap_auth_enabled')),
-  allow_unauthorized_cert      = validator.toBoolean(req.param('allow_unauthorized_cert')),
+  var url                      = validator.trim(req.body['url']),
+  binddn                       = validator.trim(req.body['binddn']),
+  bindcredentials              = validator.trim(req.body['bindcredentials']),
+  searchbase                   = validator.trim(req.body['searchbase']),
+  ldap_auth_enabled            = validator.toBoolean(req.body['ldap_auth_enabled']),
+  allow_unauthorized_cert      = validator.toBoolean(req.body['allow_unauthorized_cert']),
 
   // Fetch the password of current user that is valid in LDAP system
-  password_to_check = validator.trim(req.param('password_to_check'));
+  password_to_check = validator.trim(req.body['password_to_check']);
 
   // Validate provided parameters
 

--- a/lib/route/users.js
+++ b/lib/route/users.js
@@ -225,7 +225,7 @@ router.post('/import-sample/', function(req, res){
 });
 
 router.get('/edit/:user_id/', function(req, res){
-  var user_id = validator.trim(req.param('user_id'));
+  var user_id = validator.trim(req.params['user_id']);
 
   Promise.try(function(){
     ensure_user_id_is_integer({req : req, user_id : user_id});
@@ -261,7 +261,7 @@ router.get('/edit/:user_id/', function(req, res){
 
 router.get('/edit/:user_id/absences/', function(req, res){
   let
-    user_id = validator.trim(req.param('user_id')),
+    user_id = validator.trim(req.params['user_id']),
     user_allowance;
 
   Promise
@@ -351,7 +351,7 @@ router.get('/edit/:user_id/absences/', function(req, res){
 
 
 router.get('/edit/:user_id/schedule/', function(req, res){
-  var user_id = validator.trim(req.param('user_id'));
+  var user_id = validator.trim(req.params['user_id']);
 
   Promise.try(function(){
     ensure_user_id_is_integer({req : req, user_id : user_id});
@@ -489,7 +489,7 @@ var ensure_we_are_not_removing_last_admin = function(args){
 };
 
 router.post('/edit/:user_id/', function(req, res){
-  var user_id = validator.trim(req.param('user_id'));
+  var user_id = validator.trim(req.params['user_id']);
 
   var new_user_attributes,
     employee,
@@ -601,7 +601,7 @@ router.post('/edit/:user_id/', function(req, res){
 
 
 router.post('/delete/:user_id/', function(req, res){
-    const user_id = validator.trim(req.param('user_id'));
+    const user_id = validator.trim(req.params['user_id']);
     let auditCapture;
 
     Promise.try(() => ensure_user_id_is_integer({req, user_id}))
@@ -647,7 +647,7 @@ router.all('/search/', function(req, res){
     return res.redirect_with_session('../');
   }
 
-  var email = validator.trim( req.param('email') ).toLowerCase();
+  var email = validator.trim( req.body['email'] ).toLowerCase();
 
   if ( ! validator.isEmail( email )) {
     req.session.flash_error('Provided email does not look like valid one: "'+email+'"');
@@ -680,7 +680,7 @@ router.all('/search/', function(req, res){
  * */
 router.get('/', function(req, res) {
 
-    var department_id = req.param('department'),
+    var department_id = req.query['department'],
         users_filter = {},
         model = req.app.get('db_model');
 
@@ -822,7 +822,7 @@ router.get('/', function(req, res) {
         company = args[0],
         users_info = args[1];
 
-      if ( req.param('as-csv') ) {
+      if ( req.query['as-csv'] ) {
         return users_list_as_csv({
           users_info : users_info,
           company    : company,
@@ -901,17 +901,17 @@ function get_and_validate_user_parameters(args) {
         require_password = args.require_password || false;
 
     // Get user parameters
-    var name     = validator.trim(req.param('name')),
-        lastname = validator.trim(req.param('lastname')),
-        email    = validator.trim(req.param('email_address')),
-        department_id     = validator.trim(req.param('department')),
-        start_date        = validator.trim(req.param('start_date')),
-        end_date          = validator.trim(req.param('end_date')),
-        adjustment        = validator.trim(req.param('adjustment')),
-        password          = validator.trim(req.param('password_one')),
-        password_confirm  = validator.trim(req.param('password_confirm')),
-        admin             = validator.toBoolean(req.param('admin')),
-        auto_approve      = validator.toBoolean(req.param('auto_approve'));
+    var name     = validator.trim(req.body['name']),
+        lastname = validator.trim(req.body['lastname']),
+        email    = validator.trim(req.body['email_address']),
+        department_id     = validator.trim(req.body['department']),
+        start_date        = validator.trim(req.body['start_date']),
+        end_date          = validator.trim(req.body['end_date']),
+        adjustment        = validator.trim(req.body['adjustment']),
+        password          = validator.trim(req.body['password_one']),
+        password_confirm  = validator.trim(req.body['password_confirm']),
+        admin             = validator.toBoolean(req.body['admin']),
+        auto_approve      = validator.toBoolean(req.body['auto_approve']);
 
     // Validate provided parameters
 

--- a/lib/route/validator/leave_request.js
+++ b/lib/route/validator/leave_request.js
@@ -8,13 +8,13 @@ var validator = require('validator'),
 module.exports = function(args){
     var req = args.req;
 
-    var user           = validator.trim( req.param('user') ),
-        leave_type     = validator.trim( req.param('leave_type') ),
-        from_date      = validator.trim( req.param('from_date') ),
-        from_date_part = validator.trim( req.param('from_date_part') ),
-        to_date        = validator.trim( req.param('to_date') ),
-        to_date_part   = validator.trim( req.param('to_date_part') ),
-        reason         = validator.trim( req.param('reason') );
+    var user           = validator.trim( req.body['user'] ),
+        leave_type     = validator.trim( req.body['leave_type'] ),
+        from_date      = validator.trim( req.body['from_date'] ),
+        from_date_part = validator.trim( req.body['from_date_part'] ),
+        to_date        = validator.trim( req.body['to_date'] ),
+        to_date_part   = validator.trim( req.body['to_date_part'] ),
+        reason         = validator.trim( req.body['reason'] );
 
     if (user && !validator.isNumeric(user)){
         req.session.flash_error('Incorrect employee');

--- a/t/lib/mock_express_request.js
+++ b/t/lib/mock_express_request.js
@@ -19,9 +19,7 @@ module.exports = function(args){
             normalise_date : function(date) { return date; },
           },
         },
-        param   : function(key){
-            return params[key];
-        },
+        body : params,
     };
 
     // Make request be aware of flash messages


### PR DESCRIPTION
This fixes #49 by replacing all calls to deprecated `req.param` by `req.params`, `req.body`, or `req.query`.