### PR TITLE
fix: show deactivated label only on the general tab

### DIFF
--- a/views/user_details.hbs
+++ b/views/user_details.hbs
@@ -1,7 +1,7 @@
 
 {{> header }}
 
-<h1>{{employee.name}} {{employee.lastname}}'s details {{#unless is_active}}<span class="badge alert-warning">Deactivated</span>{{/unless}}</h1>
+<h1>{{employee.name}} {{employee.lastname}}'s details {{# if show_main_tab }}{{#unless is_active}}<span class="badge alert-warning">Deactivated</span>{{/unless}}{{/if}}</h1>
 
 <div class="row">
     <div class="col-md-3 lead">Employee details</div>


### PR DESCRIPTION
This fixes #384 by displaying the _Deactivated_ badge only in the general tab, not in _Schedule_ and _Absences_ tabs.