### PR TITLE
Chore change test driver to headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ language: node_js
 node_js:
   - "v6.14.0"
 sudo: false
+addons:
+    chrome: stable
 cache:
   directories:
     - node_modules
 env:
+  - USE_CHROME=1
 before_install:
 before_script:
+  - wget https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip
+  - cd bin; unzip ../chromedriver_linux64.zip; cd ../
+  - export PATH=$PWD/bin:$PATH
   - node bin/wwww > /dev/null 2>&1 &

--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ We have quite a wide test coverage, to make sure that the main user paths work a
 
 Please run them frequently while developing the project.
 
-(make sure you have [PhantomJS](http://phantomjs.org/download.html) installed in path)
+Make sure you have Chrome driver installed in your path and Chrome browser for your platform.
+
+If you want to see the browser execute the interactions prefix with `SHOW_CHROME=1`
 
 ```bash
-npm test
+USE_CHROME=1 npm test
 ```
 
 (make sure that application with default settings is up and running)

--- a/t/integration/crud_users.js
+++ b/t/integration/crud_users.js
@@ -370,6 +370,7 @@ describe('CRUD for users', function(){
       form_params : [{
           selector : 'input[name="adjustment"]',
           value    : '1.2',
+          change_step: true,
       }],
       submit_button_selector : 'button#save_changes_btn',
       message : /New allowance adjustment of user should be either whole integer number or with half/,

--- a/t/integration/try_to_open_private_pages_with_guest.js
+++ b/t/integration/try_to_open_private_pages_with_guest.js
@@ -1,10 +1,9 @@
 
 'use strict';
 
-var test           = require('selenium-webdriver/testing'),
+var test             = require('selenium-webdriver/testing'),
     config           = require('../lib/config'),
     application_host = config.get_application_host(),
-    webdriver = require('selenium-webdriver'),
     By        = require('selenium-webdriver').By,
     expect    = require('chai').expect,
     _         = require('underscore'),
@@ -13,7 +12,8 @@ var test           = require('selenium-webdriver/testing'),
     login_user_func        = require('../lib/login_with_user'),
     register_new_user_func = require('../lib/register_new_user'),
     logout_user_func       = require('../lib/logout_user'),
-    add_new_user_func      = require('../lib/add_new_user');
+    add_new_user_func      = require('../lib/add_new_user'),
+    build_driver           = require('../lib/build_driver');
 
 
 describe('Try to access private pages with guest user', function(){
@@ -29,9 +29,7 @@ describe('Try to access private pages with guest user', function(){
       ],
       function(path) {
 
-        var driver = new webdriver.Builder()
-            .withCapabilities(webdriver.Capabilities.phantomjs())
-            .build();
+        var driver = build_driver()
 
         // Open front page
         driver.get( application_host + path);
@@ -47,10 +45,7 @@ describe('Try to access private pages with guest user', function(){
   });
 
   it('Check main (dashboard) page', function(done) {
-
-    var driver = new webdriver.Builder()
-        .withCapabilities(webdriver.Capabilities.phantomjs())
-        .build();
+    var driver = build_driver();
 
     // Open front page
     driver.get( application_host);

--- a/t/integration/users_import.js
+++ b/t/integration/users_import.js
@@ -41,7 +41,7 @@ describe('Bulk import of users', function(){
       driver,
       csv_data,
       sample_email,
-      test_users_filename =  __dirname +'/../test.csv';
+      test_users_filename =  __dirname +'/test.csv';
 
   it('Create new company', function(done){
     register_new_user_func({

--- a/t/lib/add_new_user.js
+++ b/t/lib/add_new_user.js
@@ -59,11 +59,11 @@ module.exports = Promise.promisify(function(args, callback){
         },{
             selector : add_new_user_form_id+' input[name="password_confirm"]',
             value    : '123456',
-        },{
+        },
+        select_department, {
             selector : add_new_user_form_id+' input[name="start_date"]',
             value : '2015-06-01',
         },
-            select_department,
         ],
         submit_button_selector : add_new_user_form_id+' #add_new_user_btn',
         should_be_successful : error_message ? false : true,

--- a/t/lib/add_new_user.js
+++ b/t/lib/add_new_user.js
@@ -1,14 +1,14 @@
 
 'use strict';
 
-var webdriver = require('selenium-webdriver'),
-    By        = require('selenium-webdriver').By,
+var By        = require('selenium-webdriver').By,
     expect    = require('chai').expect,
     _         = require('underscore'),
     until     = require('selenium-webdriver').until,
     Promise   = require("bluebird"),
     uuid      = require('node-uuid'),
-    submit_form_func = require('../lib/submit_form'),
+    submit_form_func = require('./submit_form'),
+    build_driver     = require('./build_driver'),
     add_new_user_form_id = '#add_new_user_form',
     driver;
 
@@ -22,9 +22,7 @@ module.exports = Promise.promisify(function(args, callback){
       // with that error
       error_message = args.error_message,
 
-  driver = args.driver || new webdriver.Builder()
-    .withCapabilities(webdriver.Capabilities.phantomjs())
-    .build();
+  driver = args.driver || build_driver();
 
   var random_token =  (new Date()).getTime();
   var new_user_email = args.email || random_token + '@test.com';

--- a/t/lib/build_driver.js
+++ b/t/lib/build_driver.js
@@ -1,0 +1,22 @@
+var webdriver     = require('selenium-webdriver'),
+    chrome        = require('selenium-webdriver/chrome')
+    capabilities  = process.env.USE_CHROME ? 'chrome' : 'phantomjs';
+
+module.exports = function() {
+  if (capabilities === 'phantomjs') {
+    return new webdriver.Builder()
+      .withCapabilities(webdriver.Capabilities[capabilities]())
+      .build();
+  }
+
+  var options = new chrome.Options();
+  if (!process.env.SHOW_CHROME) {
+    options.addArguments('headless');
+    options.addArguments('disable-gpu')
+  }
+
+  return new webdriver.Builder()
+    .withCapabilities(webdriver.Capabilities[capabilities]())
+    .setChromeOptions(options)
+    .build();
+}

--- a/t/lib/login_with_user.js
+++ b/t/lib/login_with_user.js
@@ -1,12 +1,12 @@
 
 'use strict';
 
-var webdriver = require('selenium-webdriver'),
-    By        = require('selenium-webdriver').By,
+var By        = require('selenium-webdriver').By,
     expect    = require('chai').expect,
     until     = require('selenium-webdriver').until,
     _         = require('underscore'),
     Promise   = require("bluebird"),
+    build_driver = require('./build_driver'),
     driver;
 
 
@@ -16,13 +16,10 @@ var login_with_user_func = Promise.promisify(function(args, callback){
       user_email       = args.user_email,
       result_callback  = callback,
       password         = args.password || '123456',
-      should_fail      = args.should_fail || false,
+      should_fail      = args.should_fail || false;
 
   // Create new instance of driver
-  driver = args.driver || new webdriver.Builder()
-    .withCapabilities(webdriver.Capabilities.phantomjs())
-//    .withCapabilities(webdriver.Capabilities.chrome())
-    .build();
+  driver = args.driver || build_driver();
 
   // Make sure we are in desktop version
   driver.manage().window().setSize(1024, 768);

--- a/t/lib/register_new_user.js
+++ b/t/lib/register_new_user.js
@@ -4,16 +4,16 @@
 
 'use strict';
 
-var webdriver = require('selenium-webdriver'),
-    By        = require('selenium-webdriver').By,
+var By        = require('selenium-webdriver').By,
     until     = require('selenium-webdriver').until,
     expect    = require('chai').expect,
     _         = require('underscore'),
     uuid      = require('node-uuid'),
     Promise   = require("bluebird"),
-    open_page_func       = require('../lib/open_page'),
+    open_page_func       = require('./open_page'),
+    build_driver         = require('./build_driver'),
     company_edit_form_id = '#company_edit_form',
-    submit_form_func     = require('../lib/submit_form');
+    submit_form_func     = require('./submit_form');
 
 
 var register_new_user_func = Promise.promisify( function(args, callback){
@@ -25,15 +25,9 @@ var register_new_user_func = Promise.promisify( function(args, callback){
     random_token          = (new Date()).getTime(),
     new_user_email        = args.user_email || random_token + '@test.com';
 
-  var capabilities = process.env.USE_CHROME ? 'chrome' : 'phantomjs';
-
   // Instantiate new driver object if it not provided as paramater
-  var driver = args.driver || new webdriver.Builder()
-      .withCapabilities(webdriver.Capabilities[capabilities]())
-      .build();
+  var driver = args.driver || build_driver()
 
-//  driver.manage().timeouts().pageLoadTimeout(10*1000);
-//  driver.manage().timeouts().implicitlyWait(10*1000);
 
   // Make sure we are in desktop version
   driver.manage().window().setSize(1024, 768);

--- a/t/lib/submit_form.js
+++ b/t/lib/submit_form.js
@@ -67,6 +67,11 @@ var submit_form_func = Promise.promisify( function(args, callback){
                           .then(() => driver.findElement(By.css(test_case.dropdown_option)))
                           .then(dd => dd.click())
                       } else {
+                          // Prevent the browser validations to allow backend validations to occur
+                          if (test_case.change_step) {
+                            driver.executeScript("return arguments[0].step = '0.1'", el);
+                          }
+
                           return el.clear().then(function(){
                               el.sendKeys( test_case.value );
                               // Tabs to trigger the calendars overlays

--- a/t/lib/submit_form.js
+++ b/t/lib/submit_form.js
@@ -2,6 +2,7 @@
 
 var webdriver  = require('selenium-webdriver'),
 By             = require('selenium-webdriver').By,
+Key            = require('selenium-webdriver').Key,
 expect         = require('chai').expect,
 _              = require('underscore'),
 Promise        = require("bluebird"),
@@ -68,6 +69,9 @@ var submit_form_func = Promise.promisify( function(args, callback){
                       } else {
                           return el.clear().then(function(){
                               el.sendKeys( test_case.value );
+                              // Tabs to trigger the calendars overlays
+                              // to close so the modal submit button can be clicked
+                              el.sendKeys(Key.TAB)
                           });
                       }
                   });


### PR DESCRIPTION
Hey @vpp,

As discussed I had a look moving over the test suite to use headless chrome, there were mostly a couple of changes due to slight differences between phantomjs and chrome. I also added an option to show the browser during development. With the env `SHOW_CHROME=1`

For backward compatibility I've left phantomjs in - however I couldn't test it personally, I think the changes I've made should be compatible still with phantomjs.

I've updated the travis CI config so that it uses chrome in CI, which installs the relevant chromedriver and chrome browser. _(These might get out of sync so might need to be smarter about the version of chrome driver we download in the future)_

I also updated the README to show reference to chromedriver/chrome browser is now required.

Heres the build running on my fork - https://travis-ci.com/jnormington/application/builds/131611850

## Changes

- Refactored getting a driver instance in a helper so there is a single source of building driver instance
- Presses tab key after inputting a value (yes for every field), but it solves the issue with the calendar overlays not closing (because we trigger the field input text) and don't interact with the calendar causing it not to close.
- Alters the number element and alters the step attribute to 0.1 when `change_step` is passed to `submit_form_func`. This allows us not to get client side validation from the browser and instead get it triggered by the backend like phantomjs.
- Updates the test_data_csv path to be absolute for chrome
- Changes when we select department when there is only a single entry that we also select it doesn't cause the select field to close, so we need other input actions to happen before click action so the select auto closes.