### PR TITLE
fix: upgrade mocha to 6.2.2 to fix potential security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "chai": "^2.2.0",
-    "mocha": "^3.5.3",
+    "mocha": "^6.2.2",
     "node-sass": "^4.5.3",
     "request-promise": "^4.2.2",
     "selenium-webdriver": "2.53.3"


### PR DESCRIPTION
Upgrade mocha to V6.2.2 to fix potential critical security issue (reported in `npm audit`).
Not urgent as it is used only for tests, but tests are running fine with this version so no real reason not to upgrade.