### PR TITLE
fix: remove unused fetching of company feed

### DIFF
--- a/lib/route/calendar.js
+++ b/lib/route/calendar.js
@@ -189,7 +189,6 @@ router.get('/feeds/', function(req, res){
       return Promise.join(
         promise_feed_of_type({user : req.user, feeds: feeds, type : 'calendar'}),
         promise_feed_of_type({user : req.user, feeds: feeds, type : 'teamview'}),
-        promise_feed_of_type({user : req.user, feeds: feeds, type : 'company'}),
         function(calendar_feed, team_view_feed){
           res.render('feeds_list', {
             title         : 'My feeds',


### PR DESCRIPTION
This closes #407 by removing the unused company feed